### PR TITLE
Fix for Sphinx-generated warnings

### DIFF
--- a/examples/plot_mne_sample_gridsearch.py
+++ b/examples/plot_mne_sample_gridsearch.py
@@ -72,8 +72,7 @@ data = epochs.get_data()
 
 pipe = Pipeline([('fe', FeatureExtractor(sfreq=raw.info['sfreq'],
                                          selected_funcs=['app_entropy',
-                                                         'mean'],
-                                         memory='.')),
+                                                         'mean'])),
                  ('scaler', StandardScaler()),
                  ('clf', LogisticRegression(random_state=42))])
 skf = StratifiedKFold(n_splits=3, random_state=42)
@@ -96,7 +95,8 @@ print('Cross-validation accuracy score (with default parameters) = %1.3f '
 params_grid = {'fe__app_entropy__emb': np.arange(2, 5)}
 
 gs = GridSearchCV(estimator=pipe, param_grid=params_grid,
-                  cv=StratifiedKFold(n_splits=2, random_state=42), n_jobs=1)
+                  cv=StratifiedKFold(n_splits=2, random_state=42), n_jobs=1,
+                  return_train_score=True)
 gs.fit(data, y)
 
 # Best parameters obtained with GridSearchCV:

--- a/examples/plot_seizure_example.py
+++ b/examples/plot_seizure_example.py
@@ -21,17 +21,8 @@ Proc. IEEE ICASSP Conf. 2018
 
     This example is for illustration purposes, as other methods
     may lead to better performance on such a dataset (classification of
-    "seizure" vs. "non-seizure" iEEG segments).
-
-References
-----------
-
-.. [1] Andrzejak, R. G. et al. (2001). Indications of nonlinear deterministic
-       and finite-dimensional structures in time series of brain electrical
-       activity: Dependence on recording region and brain state. Physical
-       Review E, 64(6), 061907.
-
-.. [2] http://epileptologie-bonn.de/cms/front_content.php?idcat=193&lang=3
+    "seizure" vs. "non-seizure" iEEG segments). For further information, see 
+    (Andrzejak et al., 2001) and http://epileptologie-bonn.de.
 """
 
 # Author: Jean-Baptiste Schiratti <jean.baptiste.schiratti@gmail.com>

--- a/examples/plot_seizure_example.py
+++ b/examples/plot_seizure_example.py
@@ -21,7 +21,7 @@ Proc. IEEE ICASSP Conf. 2018
 
     This example is for illustration purposes, as other methods
     may lead to better performance on such a dataset (classification of
-    "seizure" vs. "non-seizure" iEEG segments). For further information, see 
+    "seizure" vs. "non-seizure" iEEG segments). For further information, see
     (Andrzejak et al., 2001) and http://epileptologie-bonn.de.
 """
 

--- a/examples/plot_user_defined_function.py
+++ b/examples/plot_user_defined_function.py
@@ -94,8 +94,7 @@ def compute_medfilt(arr):
 selected_funcs = [('medfilt', compute_medfilt), 'mean']
 
 pipe = Pipeline([('fe', FeatureExtractor(sfreq=raw.info['sfreq'],
-                                         selected_funcs=selected_funcs,
-                                         memory='.')),
+                                         selected_funcs=selected_funcs)),
                  ('scaler', StandardScaler()),
                  ('clf', LogisticRegression(random_state=42))])
 skf = StratifiedKFold(n_splits=3, random_state=42)

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -101,7 +101,7 @@ def _max_cross_corr(sfreq, data, include_diag=False):
 
 
 def compute_max_cross_corr(sfreq, data, include_diag=False):
-    """Maximum linear cross-correlation ([Morm06]_, [Miro08]_).
+    """Maximum linear cross-correlation.
 
     Parameters
     ----------
@@ -126,20 +126,23 @@ def compute_max_cross_corr(sfreq, data, include_diag=False):
 
     Notes
     -----
-    Alias of the feature function: **max_cross_corr**
+    Alias of the feature function: **max_cross_corr**. See [1]_ and [2]_.
 
     References
     ----------
-    .. [Miro08] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional
-                networks for epileptic seizure prediction from intracranial
-                EEG. Machine Learning for Signal Processing, 2008. IEEE
-                Workshop on (pp. 244-249). IEEE.
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and 
+           winding road. Brain, 130(2), 314-333.
+
+    .. [2] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional 
+           networks for epileptic seizure prediction from intracranial EEG. 
+           Machine Learning for Signal Processing, 2008. IEEE Workshop on 
+           (pp. 244-249). IEEE.
     """
     return _max_cross_corr(sfreq, data, include_diag=include_diag)
 
 
 def compute_phase_lock_val(data, include_diag=False):
-    """Phase Locking Value (PLV) ([Plv]_).
+    """Phase Locking Value (PLV).
 
     Parameters
     ----------
@@ -159,11 +162,11 @@ def compute_phase_lock_val(data, include_diag=False):
 
     Notes
     -----
-    Alias of the feature function: **phase_lock_val**
+    Alias of the feature function: **phase_lock_val**. See [1]_.
 
     References
     ----------
-    .. [Plv] http://www.gatsby.ucl.ac.uk/~vincenta/kaggle/report.pdf
+    .. [1] http://www.gatsby.ucl.ac.uk/~vincenta/kaggle/report.pdf
     """
     n_channels, n_times = data.shape
     if include_diag:
@@ -184,7 +187,7 @@ def compute_phase_lock_val(data, include_diag=False):
 
 
 def compute_nonlin_interdep(data, tau=2, emb=10, nn=5, include_diag=False):
-    """Measure of nonlinear interdependence ([Morm06]_, [Miro08]_).
+    """Measure of nonlinear interdependence.
 
     Parameters
     ----------
@@ -215,7 +218,17 @@ def compute_nonlin_interdep(data, tau=2, emb=10, nn=5, include_diag=False):
 
     Notes
     -----
-    Alias of the feature function: **nonlin_interdep**
+    Alias of the feature function: **nonlin_interdep**. See [1]_ and [2]_.
+
+    References
+    ----------
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and 
+           winding road. Brain, 130(2), 314-333.
+
+    .. [2] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional 
+           networks for epileptic seizure prediction from intracranial EEG. 
+           Machine Learning for Signal Processing, 2008. IEEE Workshop on 
+           (pp. 244-249). IEEE.
     """
     n_channels, n_times = data.shape
     if include_diag:
@@ -243,7 +256,7 @@ def compute_nonlin_interdep(data, tau=2, emb=10, nn=5, include_diag=False):
 
 
 def compute_time_corr(data, with_eigenvalues=True, include_diag=False):
-    """Correlation Coefficients (computed in the time domain) ([Tisp]_).
+    """Correlation Coefficients (computed in the time domain).
 
     Parameters
     ----------
@@ -270,12 +283,12 @@ def compute_time_corr(data, with_eigenvalues=True, include_diag=False):
 
     Notes
     -----
-    Alias of the feature function: **time_corr**
+    Alias of the feature function: **time_corr**. See [1]_.
 
     References
     ----------
-    .. [Tisp] https://kaggle2.blob.core.windows.net/forum-message-attachments/
-              134445/4803/seizure-detection.pdf
+    .. [1] https://kaggle2.blob.core.windows.net/forum-message-attachments/
+           134445/4803/seizure-detection.pdf
     """
     n_channels = data.shape[0]
     _scaled = scale(data, axis=0)
@@ -292,7 +305,7 @@ def compute_time_corr(data, with_eigenvalues=True, include_diag=False):
 
 def compute_spect_corr(sfreq, data, db=False, with_eigenvalues=True,
                        include_diag=False):
-    """Correlation Coefficients (computed from the power spectrum) ([Tisp]_).
+    """Correlation Coefficients (computed from the power spectrum).
 
     Parameters
     ----------
@@ -326,7 +339,12 @@ def compute_spect_corr(sfreq, data, db=False, with_eigenvalues=True,
 
     Notes
     -----
-    Alias of the feature function: **spect_corr**
+    Alias of the feature function: **spect_corr**. See [1]_.
+
+    References
+    ----------
+    .. [1] https://kaggle2.blob.core.windows.net/forum-message-attachments/
+           134445/4803/seizure-detection.pdf
     """
     n_channels = data.shape[0]
     ps, _ = power_spectrum(sfreq, data, return_db=db)

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -130,12 +130,12 @@ def compute_max_cross_corr(sfreq, data, include_diag=False):
 
     References
     ----------
-    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and 
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and
            winding road. Brain, 130(2), 314-333.
 
-    .. [2] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional 
-           networks for epileptic seizure prediction from intracranial EEG. 
-           Machine Learning for Signal Processing, 2008. IEEE Workshop on 
+    .. [2] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional
+           networks for epileptic seizure prediction from intracranial EEG.
+           Machine Learning for Signal Processing, 2008. IEEE Workshop on
            (pp. 244-249). IEEE.
     """
     return _max_cross_corr(sfreq, data, include_diag=include_diag)
@@ -222,12 +222,12 @@ def compute_nonlin_interdep(data, tau=2, emb=10, nn=5, include_diag=False):
 
     References
     ----------
-    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and 
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and
            winding road. Brain, 130(2), 314-333.
 
-    .. [2] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional 
-           networks for epileptic seizure prediction from intracranial EEG. 
-           Machine Learning for Signal Processing, 2008. IEEE Workshop on 
+    .. [2] Mirowski, P. W. et al. (2008). Comparing SVM and convolutional
+           networks for epileptic seizure prediction from intracranial EEG.
+           Machine Learning for Signal Processing, 2008. IEEE Workshop on
            (pp. 244-249). IEEE.
     """
     n_channels, n_times = data.shape

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -336,12 +336,12 @@ def compute_hurst_exp(data):
 
     References
     ----------
-    .. [1] Rasheed, B. Q. K. et al. (2004). Hurst exponent and financial 
-           market predictability. In IASTED conference on Financial 
+    .. [1] Rasheed, B. Q. K. et al. (2004). Hurst exponent and financial
+           market predictability. In IASTED conference on Financial
            Engineering and Applications (FEA 2004) (pp. 203-209).
 
     .. [2] Devarajan, K. et al. (2014). EEG-Based Epilepsy Detection and
-           Prediction. International Journal of Engineering and Technology, 
+           Prediction. International Journal of Engineering and Technology,
            6(3), 212.
     """
     n_channels, n_times = data.shape
@@ -429,8 +429,8 @@ def compute_app_entropy(data, emb=2, metric='chebyshev'):
 
     References
     ----------
-    .. [1] Richman, J. S. et al. (2000). Physiological time-series analysis 
-           using approximate entropy and sample entropy. American Journal of 
+    .. [1] Richman, J. S. et al. (2000). Physiological time-series analysis
+           using approximate entropy and sample entropy. American Journal of
            Physiology-Heart and Circulatory Physiology, 278(6), H2039-H2049.
     """
     phi = _app_samp_entropy_helper(data, emb=emb, metric=metric,
@@ -462,8 +462,8 @@ def compute_samp_entropy(data, emb=2, metric='chebyshev'):
 
     References
     ----------
-    .. [1] Richman, J. S. et al. (2000). Physiological time-series analysis 
-           using approximate entropy and sample entropy. American Journal of 
+    .. [1] Richman, J. S. et al. (2000). Physiological time-series analysis
+           using approximate entropy and sample entropy. American Journal of
            Physiology-Heart and Circulatory Physiology, 278(6), H2039-H2049.
     """
     phi = _app_samp_entropy_helper(data, emb=emb, metric=metric,
@@ -494,8 +494,8 @@ def compute_decorr_time(sfreq, data):
 
     References
     ----------
-    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for 
-           studies on the prediction of epileptic seizures. Journal of 
+    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for
+           studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
     n_channels, n_times = data.shape
@@ -595,11 +595,11 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
 
     Notes
     -----
-    Alias of the feature function: **pow_freq_bands**. See [1]_. 
-    
+    Alias of the feature function: **pow_freq_bands**. See [1]_.
+
     References
     ----------
-    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for 
+    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for
            studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
@@ -652,12 +652,12 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False):
 
     Notes
     -----
-    Alias of the feature function: **hjorth_mobility_spect**. See [1]_ and 
-    [2]_. 
+    Alias of the feature function: **hjorth_mobility_spect**. See [1]_ and
+    [2]_.
 
     References
     ----------
-    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and 
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and
            winding road. Brain, 130(2), 314-333.
 
     .. [2] Teixeira, C. A. et al. (2011). EPILAB: A software package for
@@ -693,7 +693,7 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False):
 
     Notes
     -----
-    Alias of the feature function: **hjorth_complexity_spect**. See [1]_ and 
+    Alias of the feature function: **hjorth_complexity_spect**. See [1]_ and
     [2]_.
 
     References
@@ -732,8 +732,8 @@ def compute_hjorth_mobility(data):
 
     References
     ----------
-    .. [1] Paivinen, N. et al. (2005). Epileptic seizure detection: A 
-           nonlinear viewpoint. Computer methods and programs in biomedicine, 
+    .. [1] Paivinen, N. et al. (2005). Epileptic seizure detection: A
+           nonlinear viewpoint. Computer methods and programs in biomedicine,
            79(2), 151-159.
     """
     x = np.insert(data, 0, 0, axis=-1)
@@ -763,8 +763,8 @@ def compute_hjorth_complexity(data):
 
     References
     ----------
-    .. [1] Paivinen, N. et al. (2005). Epileptic seizure detection: A 
-           nonlinear viewpoint. Computer methods and programs in biomedicine, 
+    .. [1] Paivinen, N. et al. (2005). Epileptic seizure detection: A
+           nonlinear viewpoint. Computer methods and programs in biomedicine,
            79(2), 151-159.
     """
     x = np.insert(data, 0, 0, axis=-1)
@@ -839,12 +839,12 @@ def compute_higuchi_fd(data, kmax=10):
 
     References
     ----------
-    .. [1] Esteller, R. et al. (2001). A comparison of waveform fractal 
-           dimension algorithms. IEEE Transactions on Circuits and Systems I: 
+    .. [1] Esteller, R. et al. (2001). A comparison of waveform fractal
+           dimension algorithms. IEEE Transactions on Circuits and Systems I:
            Fundamental Theory and Applications, 48(2), 177-183.
 
-    .. [2] Paivinen, N. et al. (2005). Epileptic seizure detection: A 
-           nonlinear viewpoint. Computer methods and programs in biomedicine, 
+    .. [2] Paivinen, N. et al. (2005). Epileptic seizure detection: A
+           nonlinear viewpoint. Computer methods and programs in biomedicine,
            79(2), 151-159.
     """
     return _higuchi_fd(data, kmax)
@@ -867,8 +867,8 @@ def compute_katz_fd(data):
 
     References
     ----------
-    .. [1] Esteller, R. et al. (2001). A comparison of waveform fractal 
-           dimension algorithms. IEEE Transactions on Circuits and Systems I: 
+    .. [1] Esteller, R. et al. (2001). A comparison of waveform fractal
+           dimension algorithms. IEEE Transactions on Circuits and Systems I:
            Fundamental Theory and Applications, 48(2), 177-183.
     """
     dists = np.abs(np.diff(data, axis=-1))
@@ -939,9 +939,9 @@ def compute_line_length(data):
 
     References
     ----------
-    .. [1] Esteller, R. et al. (2001). Line length: an efficient feature for 
-           seizure onset detection. In Engineering in Medicine and Biology 
-           Society, 2001. Proceedings of the 23rd Annual International 
+    .. [1] Esteller, R. et al. (2001). Line length: an efficient feature for
+           seizure onset detection. In Engineering in Medicine and Biology
+           Society, 2001. Proceedings of the 23rd Annual International
            Conference of the IEEE (Vol. 2, pp. 1707-1710). IEEE.
     """
     return np.mean(np.abs(np.diff(data, axis=-1)), axis=-1)
@@ -970,8 +970,8 @@ def compute_spect_entropy(sfreq, data):
 
     References
     ----------
-    .. [1] Inouye, T. et al. (1991). Quantification of EEG irregularity by 
-           use of the entropy of the power spectrum. Electroencephalography 
+    .. [1] Inouye, T. et al. (1991). Quantification of EEG irregularity by
+           use of the entropy of the power spectrum. Electroencephalography
            and clinical neurophysiology, 79(3), 204-210.
     """
     ps, _ = power_spectrum(sfreq, data, return_db=False)
@@ -1003,8 +1003,8 @@ def compute_svd_entropy(data, tau=2, emb=10):
 
     References
     ----------
-    .. [1] Roberts, S. J. et al. (1999). Temporal and spatial complexity 
-           measures for electroencephalogram based brain-computer interfacing. 
+    .. [1] Roberts, S. J. et al. (1999). Temporal and spatial complexity
+           measures for electroencephalogram based brain-computer interfacing.
            Medical & biological engineering & computing, 37(1), 93-98.
     """
     _, sv, _ = np.linalg.svd(_embed(data, d=emb, tau=tau))
@@ -1036,8 +1036,8 @@ def compute_svd_fisher_info(data, tau=2, emb=10):
 
     References
     ----------
-    .. [1] Roberts, S. J. et al. (1999). Temporal and spatial complexity 
-           measures for electroencephalogram based brain-computer interfacing. 
+    .. [1] Roberts, S. J. et al. (1999). Temporal and spatial complexity
+           measures for electroencephalogram based brain-computer interfacing.
            Medical & biological engineering & computing, 37(1), 93-98.
     """
     _, sv, _ = np.linalg.svd(_embed(data, d=emb, tau=tau))
@@ -1086,7 +1086,7 @@ def compute_energy_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8.,
 
     References
     ----------
-    .. [1] Kharbouch, A. et al. (2011). An algorithm for seizure onset 
+    .. [1] Kharbouch, A. et al. (2011). An algorithm for seizure onset
            detection using intracranial EEG. Epilepsy & Behavior, 22, S29-S35.
     """
     n_channels = data.shape[0]
@@ -1135,7 +1135,7 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None):
 
     References
     ----------
-    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and winding 
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and winding
            road. Brain, 130(2), 314-333.
     """
     if ref_freq is None:
@@ -1188,8 +1188,8 @@ def compute_wavelet_coef_energy(data, wavelet_name='db4'):
 
     References
     ----------
-    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for 
-           studies on the prediction of epileptic seizures. Journal of 
+    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for
+           studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
     n_channels, n_times = data.shape
@@ -1247,8 +1247,8 @@ def compute_teager_kaiser_energy(data, wavelet_name='db4'):
 
     References
     ----------
-    .. [1] Badani, S. et al. (2017). Detection of epilepsy based on discrete 
-           wavelet transform and Teager-Kaiser energy operator. In Calcutta 
+    .. [1] Badani, S. et al. (2017). Detection of epilepsy based on discrete
+           wavelet transform and Teager-Kaiser energy operator. In Calcutta
            Conference (CALCON). 2017 IEEE (pp. 164-167).
     """
     n_channels, n_times = data.shape

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -320,7 +320,7 @@ def _hurst_exp_helper(x, n_splits=20):
 
 
 def compute_hurst_exp(data):
-    """Hurst exponent of the data (per channel) ([Rash04]_, [Deva14]_).
+    """Hurst exponent of the data (per channel).
 
     Parameters
     ----------
@@ -332,17 +332,17 @@ def compute_hurst_exp(data):
 
     Notes
     -----
-    Alias of the feature function: **hurst_exp**
+    Alias of the feature function: **hurst_exp**. See [1]_ and [2]_.
 
     References
     ----------
-    .. [Rash04] Rasheed, B. Q. K. et al. (2004). Hurst exponent and financial
-                market predictability. In IASTED conference on Financial
-                Engineering and Applications (FEA 2004) (pp. 203-209).
+    .. [1] Rasheed, B. Q. K. et al. (2004). Hurst exponent and financial 
+           market predictability. In IASTED conference on Financial 
+           Engineering and Applications (FEA 2004) (pp. 203-209).
 
-    .. [Deva14] Devarajan, K. et al. (2014). EEG-Based Epilepsy Detection and
-                Prediction. International Journal of Engineering and
-                Technology, 6(3), 212.
+    .. [2] Devarajan, K. et al. (2014). EEG-Based Epilepsy Detection and
+           Prediction. International Journal of Engineering and Technology, 
+           6(3), 212.
     """
     n_channels, n_times = data.shape
     hurst = np.empty((n_channels,))
@@ -405,7 +405,7 @@ def _app_samp_entropy_helper(data, emb, metric='chebyshev',
 
 
 def compute_app_entropy(data, emb=2, metric='chebyshev'):
-    """Approximate Entropy (AppEn, per channel) ([Rich00]_).
+    """Approximate Entropy (AppEn, per channel).
 
     Parameters
     ----------
@@ -425,14 +425,13 @@ def compute_app_entropy(data, emb=2, metric='chebyshev'):
 
     Notes
     -----
-    Alias of the feature function: **app_entropy**
+    Alias of the feature function: **app_entropy**. See [1]_.
 
     References
     ----------
-    .. [Rich00] Richman, J. S. et al. (2000). Physiological time-series
-                analysis using approximate entropy and sample entropy.
-                American Journal of Physiology-Heart and Circulatory
-                Physiology, 278(6), H2039-H2049.
+    .. [1] Richman, J. S. et al. (2000). Physiological time-series analysis 
+           using approximate entropy and sample entropy. American Journal of 
+           Physiology-Heart and Circulatory Physiology, 278(6), H2039-H2049.
     """
     phi = _app_samp_entropy_helper(data, emb=emb, metric=metric,
                                    approximate=True)
@@ -440,7 +439,7 @@ def compute_app_entropy(data, emb=2, metric='chebyshev'):
 
 
 def compute_samp_entropy(data, emb=2, metric='chebyshev'):
-    """Sample Entropy (SampEn, per channel) ([Rich00]_).
+    """Sample Entropy (SampEn, per channel).
 
     Parameters
     ----------
@@ -459,7 +458,13 @@ def compute_samp_entropy(data, emb=2, metric='chebyshev'):
 
     Notes
     -----
-    Alias of the feature function: **samp_entropy**
+    Alias of the feature function: **samp_entropy**. See [1]_.
+
+    References
+    ----------
+    .. [1] Richman, J. S. et al. (2000). Physiological time-series analysis 
+           using approximate entropy and sample entropy. American Journal of 
+           Physiology-Heart and Circulatory Physiology, 278(6), H2039-H2049.
     """
     phi = _app_samp_entropy_helper(data, emb=emb, metric=metric,
                                    approximate=False)
@@ -470,7 +475,7 @@ def compute_samp_entropy(data, emb=2, metric='chebyshev'):
 
 
 def compute_decorr_time(sfreq, data):
-    """Decorrelation time (per channel) ([Teix11]_).
+    """Decorrelation time (per channel).
 
     Parameters
     ----------
@@ -485,13 +490,13 @@ def compute_decorr_time(sfreq, data):
 
     Notes
     -----
-    Alias of the feature function: **decorr_time**
+    Alias of the feature function: **decorr_time**. See [1]_.
 
     References
     ----------
-    .. [Teix11] Teixeira, C. A. et al. (2011). EPILAB: A software package for
-                studies on the prediction of epileptic seizures. Journal of
-                Neuroscience Methods, 200(2), 257-271.
+    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for 
+           studies on the prediction of epileptic seizures. Journal of 
+           Neuroscience Methods, 200(2), 257-271.
     """
     n_channels, n_times = data.shape
     decorrelation_times = np.empty((n_channels,))
@@ -549,7 +554,7 @@ def _freq_bands_helper(sfreq, freq_bands):
 def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
                                                              30., 100.]),
                            normalize=True, ratios=None):
-    """Power Spectrum (computed by frequency bands) ([Teix11]_).
+    """Power Spectrum (computed by frequency bands).
 
     Parameters
     ----------
@@ -590,7 +595,13 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
 
     Notes
     -----
-    Alias of the feature function: **pow_freq_bands**
+    Alias of the feature function: **pow_freq_bands**. See [1]_. 
+    
+    References
+    ----------
+    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for 
+           studies on the prediction of epileptic seizures. Journal of
+           Neuroscience Methods, 200(2), 257-271.
     """
     n_channels = data.shape[0]
     fb = _freq_bands_helper(sfreq, freq_bands)
@@ -621,7 +632,7 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
 
 
 def compute_hjorth_mobility_spect(sfreq, data, normalize=False):
-    """Hjorth mobility (per channel) ([Morm06]_, [Teix11]_).
+    """Hjorth mobility (per channel).
 
     Hjorth mobility parameter computed from the Power Spectrum of the data.
 
@@ -633,7 +644,7 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False):
     data : ndarray, shape (n_channels, n_times)
 
     normalize : bool (default: False)
-        Normalize the result by the total power (see [Teix11]_).
+        Normalize the result by the total power.
 
     Returns
     -------
@@ -641,12 +652,17 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False):
 
     Notes
     -----
-    Alias of the feature function: **hjorth_mobility_spect**
+    Alias of the feature function: **hjorth_mobility_spect**. See [1]_ and 
+    [2]_. 
 
     References
     ----------
-    .. [Morm06] Mormann, F. et al. (2006). Seizure prediction: the long and
-                winding road. Brain, 130(2), 314-333.
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and 
+           winding road. Brain, 130(2), 314-333.
+
+    .. [2] Teixeira, C. A. et al. (2011). EPILAB: A software package for
+           studies on the prediction of epileptic seizures. Journal of
+           Neuroscience Methods, 200(2), 257-271.
     """
     ps, freqs = power_spectrum(sfreq, data)
     w_freqs = np.power(freqs, 2)
@@ -657,7 +673,7 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False):
 
 
 def compute_hjorth_complexity_spect(sfreq, data, normalize=False):
-    """Hjorth complexity (per channel) ([Morm06]_, [Teix11]_).
+    """Hjorth complexity (per channel).
 
     Hjorth complexity parameter computed from the Power Spectrum of the data.
 
@@ -669,7 +685,7 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False):
     data : ndarray, shape (n_channels, n_times)
 
     normalize : bool (default: False)
-        Normalize the result by the total power (see [2]).
+        Normalize the result by the total power.
 
     Returns
     -------
@@ -677,7 +693,17 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False):
 
     Notes
     -----
-    Alias of the feature function: **hjorth_complexity_spect**
+    Alias of the feature function: **hjorth_complexity_spect**. See [1]_ and 
+    [2]_.
+
+    References
+    ----------
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and
+           winding road. Brain, 130(2), 314-333.
+
+    .. [2] Teixeira, C. A. et al. (2011). EPILAB: A software package for
+           studies on the prediction of epileptic seizures. Journal of
+           Neuroscience Methods, 200(2), 257-271.
     """
     ps, freqs = power_spectrum(sfreq, data)
     w_freqs = np.power(freqs, 4)
@@ -688,7 +714,7 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False):
 
 
 def compute_hjorth_mobility(data):
-    """Hjorth mobility (per channel) ([Paiv05]_).
+    """Hjorth mobility (per channel).
 
     Hjorth mobility parameter computed in the time domain.
 
@@ -702,13 +728,13 @@ def compute_hjorth_mobility(data):
 
     Notes
     -----
-    Alias of the feature function: **hjorth_mobility**
+    Alias of the feature function: **hjorth_mobility**. See [1]_.
 
     References
     ----------
-    .. [Paiv05] Paivinen, N. et al. (2005). Epileptic seizure detection: A
-                nonlinear viewpoint. Computer methods and programs in
-                biomedicine, 79(2), 151-159.
+    .. [1] Paivinen, N. et al. (2005). Epileptic seizure detection: A 
+           nonlinear viewpoint. Computer methods and programs in biomedicine, 
+           79(2), 151-159.
     """
     x = np.insert(data, 0, 0, axis=-1)
     dx = np.diff(x, axis=-1)
@@ -719,7 +745,7 @@ def compute_hjorth_mobility(data):
 
 
 def compute_hjorth_complexity(data):
-    """Hjorth complexity (per channel) ([Paiv05]_).
+    """Hjorth complexity (per channel).
 
     Hjorth complexity parameter computed in the time domain.
 
@@ -733,7 +759,13 @@ def compute_hjorth_complexity(data):
 
     Notes
     -----
-    Alias of the feature function: **hjorth_complexity**
+    Alias of the feature function: **hjorth_complexity**. See [1]_.
+
+    References
+    ----------
+    .. [1] Paivinen, N. et al. (2005). Epileptic seizure detection: A 
+           nonlinear viewpoint. Computer methods and programs in biomedicine, 
+           79(2), 151-159.
     """
     x = np.insert(data, 0, 0, axis=-1)
     dx = np.diff(x, axis=-1)
@@ -788,7 +820,7 @@ def _higuchi_fd(data, kmax):
 
 
 def compute_higuchi_fd(data, kmax=10):
-    """Higuchi Fractal Dimension (per channel) ([Este01a]_, [Paiv05]_).
+    """Higuchi Fractal Dimension (per channel).
 
     Parameters
     ----------
@@ -803,20 +835,23 @@ def compute_higuchi_fd(data, kmax=10):
 
     Notes
     -----
-    Alias of the feature function: **higuchi_fd**
+    Alias of the feature function: **higuchi_fd**. See [1]_ and [2]_.
 
     References
     ----------
-    .. [Este01a] Esteller, R. et al. (2001). A comparison of waveform fractal
-                 dimension algorithms. IEEE Transactions on Circuits and
-                 Systems I: Fundamental Theory and Applications, 48(2),
-                 177-183.
+    .. [1] Esteller, R. et al. (2001). A comparison of waveform fractal 
+           dimension algorithms. IEEE Transactions on Circuits and Systems I: 
+           Fundamental Theory and Applications, 48(2), 177-183.
+
+    .. [2] Paivinen, N. et al. (2005). Epileptic seizure detection: A 
+           nonlinear viewpoint. Computer methods and programs in biomedicine, 
+           79(2), 151-159.
     """
     return _higuchi_fd(data, kmax)
 
 
 def compute_katz_fd(data):
-    """Katz Fractal Dimension (per channel) ([Este01a]_).
+    """Katz Fractal Dimension (per channel).
 
     Parameters
     ----------
@@ -828,7 +863,13 @@ def compute_katz_fd(data):
 
     Notes
     -----
-    Alias of the feature function: **katz_fd**
+    Alias of the feature function: **katz_fd**. See [1]_.
+
+    References
+    ----------
+    .. [1] Esteller, R. et al. (2001). A comparison of waveform fractal 
+           dimension algorithms. IEEE Transactions on Circuits and Systems I: 
+           Fundamental Theory and Applications, 48(2), 177-183.
     """
     dists = np.abs(np.diff(data, axis=-1))
     ll = np.sum(dists, axis=-1)
@@ -882,7 +923,7 @@ def compute_zero_crossings(data):
 
 
 def compute_line_length(data):
-    """Line length (per channel) ([Este01b]_).
+    """Line length (per channel).
 
     Parameters
     ----------
@@ -894,21 +935,20 @@ def compute_line_length(data):
 
     Notes
     -----
-    Alias of the feature function: **line_length**
+    Alias of the feature function: **line_length**. See [1]_.
 
     References
     ----------
-    .. [Este01b] Esteller, R. et al. (2001). Line length: an efficient feature
-                 for seizure onset detection. In Engineering in Medicine and
-                 Biology Society, 2001. Proceedings of the 23rd Annual
-                 International Conference of the IEEE (Vol. 2, pp. 1707-1710).
-                 IEEE.
+    .. [1] Esteller, R. et al. (2001). Line length: an efficient feature for 
+           seizure onset detection. In Engineering in Medicine and Biology 
+           Society, 2001. Proceedings of the 23rd Annual International 
+           Conference of the IEEE (Vol. 2, pp. 1707-1710). IEEE.
     """
     return np.mean(np.abs(np.diff(data, axis=-1)), axis=-1)
 
 
 def compute_spect_entropy(sfreq, data):
-    """Spectral Entropy (per channel) ([Inou91]_).
+    """Spectral Entropy (per channel).
 
     Spectral Entropy is defined to be the Shannon Entropy of the Power
     Spectrum of the data.
@@ -926,14 +966,13 @@ def compute_spect_entropy(sfreq, data):
 
     Notes
     -----
-    Alias of the feature function: **spect_entropy**
+    Alias of the feature function: **spect_entropy**. See [1]_.
 
     References
     ----------
-    .. [Inou91] Inouye, T. et al. (1991). Quantification of EEG irregularity by
-                use of the entropy of the power spectrum.
-                Electroencephalography and clinical neurophysiology, 79(3),
-                204-210.
+    .. [1] Inouye, T. et al. (1991). Quantification of EEG irregularity by 
+           use of the entropy of the power spectrum. Electroencephalography 
+           and clinical neurophysiology, 79(3), 204-210.
     """
     ps, _ = power_spectrum(sfreq, data, return_db=False)
     m = np.sum(ps, axis=-1)
@@ -942,7 +981,7 @@ def compute_spect_entropy(sfreq, data):
 
 
 def compute_svd_entropy(data, tau=2, emb=10):
-    """SVD entropy (per channel) ([Robe99]_).
+    """SVD entropy (per channel).
 
     Parameters
     ----------
@@ -960,14 +999,13 @@ def compute_svd_entropy(data, tau=2, emb=10):
 
     Notes
     -----
-    Alias of the feature function: **svd_entropy**
+    Alias of the feature function: **svd_entropy**. See [1]_.
 
     References
     ----------
-    .. [Robe99] Roberts, S. J. et al. (1999). Temporal and spatial complexity
-                measures for electroencephalogram based brain-computer
-                interfacing. Medical & biological engineering & computing,
-                37(1), 93-98.
+    .. [1] Roberts, S. J. et al. (1999). Temporal and spatial complexity 
+           measures for electroencephalogram based brain-computer interfacing. 
+           Medical & biological engineering & computing, 37(1), 93-98.
     """
     _, sv, _ = np.linalg.svd(_embed(data, d=emb, tau=tau))
     m = np.sum(sv, axis=-1)
@@ -976,7 +1014,7 @@ def compute_svd_entropy(data, tau=2, emb=10):
 
 
 def compute_svd_fisher_info(data, tau=2, emb=10):
-    """SVD Fisher Information (per channel) ([Robe99]_).
+    """SVD Fisher Information (per channel).
 
     Parameters
     ----------
@@ -994,7 +1032,13 @@ def compute_svd_fisher_info(data, tau=2, emb=10):
 
     Notes
     -----
-    Alias of the feature function: **svd_fisher_info**
+    Alias of the feature function: **svd_fisher_info**. See [1]_.
+
+    References
+    ----------
+    .. [1] Roberts, S. J. et al. (1999). Temporal and spatial complexity 
+           measures for electroencephalogram based brain-computer interfacing. 
+           Medical & biological engineering & computing, 37(1), 93-98.
     """
     _, sv, _ = np.linalg.svd(_embed(data, d=emb, tau=tau))
     m = np.sum(sv, axis=-1)
@@ -1007,7 +1051,7 @@ def compute_energy_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8.,
                                                                 13., 30.,
                                                                 100.]),
                               deriv_filt=True):
-    """Band energy (per channel) ([Khar11]_).
+    """Band energy (per channel).
 
     Parameters
     ----------
@@ -1038,13 +1082,12 @@ def compute_energy_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8.,
 
     Notes
     -----
-    Alias of the feature function: **energy_freq_bands**
+    Alias of the feature function: **energy_freq_bands**. See [1]_.
 
     References
     ----------
-    .. [Khar11] Kharbouch, A. et al. (2011). An algorithm for seizure onset
-                detection using intracranial EEG. Epilepsy & Behavior, 22,
-                S29-S35.
+    .. [1] Kharbouch, A. et al. (2011). An algorithm for seizure onset 
+           detection using intracranial EEG. Epilepsy & Behavior, 22, S29-S35.
     """
     n_channels = data.shape[0]
     fb = _freq_bands_helper(sfreq, freq_bands)
@@ -1061,7 +1104,7 @@ def compute_energy_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8.,
 
 
 def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None):
-    """Spectal Edge Frequency (per channel) ([Morm06]_).
+    """Spectal Edge Frequency (per channel).
 
     Parameters
     ----------
@@ -1088,7 +1131,12 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None):
 
     Notes
     -----
-    Alias of the feature function: **spect_edge_freq**
+    Alias of the feature function: **spect_edge_freq**. See [1]_.
+
+    References
+    ----------
+    .. [1] Mormann, F. et al. (2006). Seizure prediction: the long and winding 
+           road. Brain, 130(2), 314-333.
     """
     if ref_freq is None:
         _ref_freq = sfreq / 2
@@ -1116,7 +1164,7 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None):
 
 
 def compute_wavelet_coef_energy(data, wavelet_name='db4'):
-    """Energy of Wavelet decomposition coefficients (per channel) ([Teix11]_).
+    """Energy of Wavelet decomposition coefficients (per channel).
 
     Parameters
     ----------
@@ -1136,7 +1184,13 @@ def compute_wavelet_coef_energy(data, wavelet_name='db4'):
 
     Notes
     -----
-    Alias of the feature function: **wavelet_coef_energy**
+    Alias of the feature function: **wavelet_coef_energy**. See [1]_.
+
+    References
+    ----------
+    .. [1] Teixeira, C. A. et al. (2011). EPILAB: A software package for 
+           studies on the prediction of epileptic seizures. Journal of 
+           Neuroscience Methods, 200(2), 257-271.
     """
     n_channels, n_times = data.shape
     coefs = _wavelet_coefs(data, wavelet_name)
@@ -1172,7 +1226,7 @@ def _tk_energy(data):
 
 
 def compute_teager_kaiser_energy(data, wavelet_name='db4'):
-    """Compute the Teager-Kaiser energy ([Bada17]_).
+    """Compute the Teager-Kaiser energy.
 
     Parameters
     ----------
@@ -1189,13 +1243,13 @@ def compute_teager_kaiser_energy(data, wavelet_name='db4'):
 
     Notes
     -----
-    Alias of the feature function: **teager_kaiser_energy**
+    Alias of the feature function: **teager_kaiser_energy**. See [1]_.
 
     References
     ----------
-    .. [Bada17] Badani, S. et al. (2017). Detection of epilepsy based on
-                discrete wavelet transform and Teager-Kaiser energy operator.
-                In Calcutta Conference (CALCON). 2017 IEEE (pp. 164-167).
+    .. [1] Badani, S. et al. (2017). Detection of epilepsy based on discrete 
+           wavelet transform and Teager-Kaiser energy operator. In Calcutta 
+           Conference (CALCON). 2017 IEEE (pp. 164-167).
     """
     n_channels, n_times = data.shape
     coefs = _wavelet_coefs(data, wavelet_name)


### PR DESCRIPTION
When building the doc of MNE-Features (with Sphinx 1.6.6 and sphinx-gallery 0.1.13), two kind of warnings/errors would be raised:

1. `Citation not found` warnings caused by citations in `References` sections (see #23).
2. A joblib error caused by using `memory='.'`  with `Pipeline` for some examples.

Issue 1. was solved by moving citations (of the form `[ref]_`) in the `Notes` section. 
Issue 2. was solved by removing `memory='.'` in the examples which raised an error. Although it would be better if we could leave `memory='.'` in `Pipeline` to avoid recomputing the features.