### PR TITLE
Use other methods than FFT to compute the PSD

### DIFF
--- a/examples/plot_psd_slope_estimation.py
+++ b/examples/plot_psd_slope_estimation.py
@@ -6,7 +6,7 @@ Estimation of the slope and intercept of the Power Spectral Density
 This example aims at showing how the utility function `power_spectrum` and 
 the feature function :func:`mne_features.univariate.compute_spect_slope` can 
 be used to estimate the slope and the intercept of the Power Spectral 
-Density (PSD, computed using the FFT of the signal).
+Density (PSD, computed - by default - using Welch method).
 
 The code for this example is based on the method proposed in:
 
@@ -58,13 +58,12 @@ raw.filter(.5, None, fir_design='firwin')
 
 data, _ = raw[1, :2048]
 sfreq = raw.info['sfreq']
-psd_method = 'multitaper'
 
-# Compute the (one-sided) PSD using FFT. The ``mask`` variable allows to
-# select only the part of the PSD which corresponds to frequencies between
+# Compute the (one-sided) PSD using Welch method. The ``mask`` variable allows
+# to select only the part of the PSD which corresponds to frequencies between
 # 0.1Hz and 40Hz (the data used in this example is already low-pass filtered
 # at 40Hz).
-psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+psd, freqs = power_spectrum(sfreq, data)
 mask = np.logical_and(1 <= freqs, freqs <= 40)
 psd, freqs = psd[0, mask], freqs[mask]
 
@@ -75,8 +74,7 @@ psd, freqs = psd[0, mask], freqs[mask]
 # the variables ``slope`` and ``intercept`` differ from the values returned
 # by ``compute_spect_slope`` because, in the feature function, the linear
 # regression fit is done in the log10-log10 scale.
-intercept, slope, _, _ = compute_spect_slope(sfreq, data, fmin=1., fmax=40.,
-                                             psd_method=psd_method)
+intercept, slope, _, _ = compute_spect_slope(sfreq, data, fmin=1., fmax=40.)
 print('The estimated slope is a = %1.2f and the estimated intercept is '
       'b = %1.3e' % (slope, intercept))
 

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -304,7 +304,8 @@ def compute_time_corr(data, with_eigenvalues=True, include_diag=False):
 
 
 def compute_spect_corr(sfreq, data, with_eigenvalues=True,
-                       include_diag=False):
+                       include_diag=False, psd_method='welch',
+                       psd_params=None):
     """Correlation Coefficients (computed from the power spectrum).
 
     Parameters
@@ -323,6 +324,16 @@ def compute_spect_corr(sfreq, data, with_eigenvalues=True,
         If False, features corresponding to pairs of identical electrodes
         are not computed. In other words, features are not computed from pairs
         of electrodes of the form ``(ch[i], ch[i])``.
+
+    psd_method : str (default: 'welch')
+        Method used for the estimation of the Power Spectral Density (PSD).
+        Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
+
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
 
     Returns
     -------
@@ -343,7 +354,11 @@ def compute_spect_corr(sfreq, data, with_eigenvalues=True,
            134445/4803/seizure-detection.pdf
     """
     n_channels = data.shape[0]
-    ps, _ = power_spectrum(sfreq, data)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        ps, _ = power_spectrum(sfreq, data, **psd_params)
+    else:
+        ps, _ = power_spectrum(sfreq, data, method=psd_method)
     _scaled = scale(ps, axis=0)
     corr = np.corrcoef(_scaled)
     coefs = corr[np.triu_indices(n_channels, 1 - int(include_diag))]

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -355,10 +355,10 @@ def compute_spect_corr(sfreq, data, with_eigenvalues=True,
     """
     n_channels = data.shape[0]
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
+        psd_params.update({'psd_method': psd_method})
         ps, _ = power_spectrum(sfreq, data, **psd_params)
     else:
-        ps, _ = power_spectrum(sfreq, data, method=psd_method)
+        ps, _ = power_spectrum(sfreq, data, psd_method=psd_method)
     _scaled = scale(ps, axis=0)
     corr = np.corrcoef(_scaled)
     coefs = corr[np.triu_indices(n_channels, 1 - int(include_diag))]

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -14,7 +14,8 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.preprocessing import scale
 
 from .mock_numba import nb
-from .utils import _idxiter, power_spectrum, _embed, _get_feature_funcs
+from .utils import (_idxiter, power_spectrum, _embed, _get_feature_funcs,
+                    _psd_params_checker)
 
 
 def get_bivariate_funcs(sfreq):
@@ -354,11 +355,8 @@ def compute_spect_corr(sfreq, data, with_eigenvalues=True,
            134445/4803/seizure-detection.pdf
     """
     n_channels = data.shape[0]
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        ps, _ = power_spectrum(sfreq, data, **psd_params)
-    else:
-        ps, _ = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    ps, _ = power_spectrum(sfreq, data, psd_method=psd_method, **_psd_params)
     _scaled = scale(ps, axis=0)
     corr = np.corrcoef(_scaled)
     coefs = corr[np.triu_indices(n_channels, 1 - int(include_diag))]

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -303,7 +303,7 @@ def compute_time_corr(data, with_eigenvalues=True, include_diag=False):
         return coefs
 
 
-def compute_spect_corr(sfreq, data, db=False, with_eigenvalues=True,
+def compute_spect_corr(sfreq, data, with_eigenvalues=True,
                        include_diag=False):
     """Correlation Coefficients (computed from the power spectrum).
 
@@ -314,10 +314,6 @@ def compute_spect_corr(sfreq, data, db=False, with_eigenvalues=True,
 
     data : ndarray, shape (n_channels, n_times)
         The signals.
-
-    db : bool (default: True)
-        If True, the power spectrum returned by the function
-        :func:`compute_power_spectrum` is returned in dB/Hz.
 
     with_eigenvalues : bool (default: True)
         If True, the function also returns the eigenvalues of the correlation
@@ -347,7 +343,7 @@ def compute_spect_corr(sfreq, data, db=False, with_eigenvalues=True,
            134445/4803/seizure-detection.pdf
     """
     n_channels = data.shape[0]
-    ps, _ = power_spectrum(sfreq, data, return_db=db)
+    ps, _ = power_spectrum(sfreq, data)
     _scaled = scale(ps, axis=0)
     corr = np.corrcoef(_scaled)
     coefs = corr[np.triu_indices(n_channels, 1 - int(include_diag))]

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -164,7 +164,8 @@ def test_decorr_time():
 
 def test_pow_freq_bands():
     expected = np.array([0, 0.005, 0, 0, 0.00125]) / 0.00625
-    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin), expected)
+    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin,
+                                               psd_method='fft'), expected)
     # Ratios of power in bands:
     # For data_sin, only the usual theta (4Hz - 8Hz) and low gamma
     # (30Hz - 70Hz) bands contain non-zero power.
@@ -172,21 +173,25 @@ def test_pow_freq_bands():
     expected_pow = np.array([0.005, 0.00125]) / 0.00625
     expected_ratios = np.array([4., 0.25])
     assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
-                                               ratios='all'),
+                                               ratios='all', psd_method='fft'),
                         np.r_[expected_pow, expected_ratios])
     assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
-                                               ratios='only'), expected_ratios)
+                                               ratios='only',
+                                               psd_method='fft'),
+                        expected_ratios)
 
 
 def test_hjorth_mobility_spect():
     expected = 0.005 * (5 ** 2) + 0.00125 * (33 ** 2)
-    assert_almost_equal(compute_hjorth_mobility_spect(sfreq, data_sin),
+    assert_almost_equal(compute_hjorth_mobility_spect(sfreq, data_sin,
+                                                      psd_method='fft'),
                         expected)
 
 
 def test_hjorth_complexity_spect():
     expected = 0.005 * (5 ** 4) + 0.00125 * (33 ** 4)
-    assert_almost_equal(compute_hjorth_complexity_spect(sfreq, data_sin),
+    assert_almost_equal(compute_hjorth_complexity_spect(sfreq, data_sin,
+                                                        psd_method='fft'),
                         expected)
 
 
@@ -296,7 +301,7 @@ def test_spect_slope():
     # We test our estimates
     intercept, slope, mse, r2 = \
         compute_spect_slope(sfreq=sfreq, data=sig.reshape(1, -1),
-                            with_intercept=True)
+                            with_intercept=True, psd_method='fft')
 
     # obtained by the expression ps[f] = 2 * [ (spect[f]^2) / (n_times^2) ]
     # and plug-in: power(f) = k1/f**theta with noise
@@ -312,7 +317,8 @@ def test_spect_slope():
 def test_spect_entropy():
     expected = -(0.005 / 0.00625) * log(0.005 / 0.00625, 2.) - \
         (0.00125 / 0.00625) * log(0.00125 / 0.00625, 2.)
-    assert_almost_equal(compute_spect_entropy(sfreq, data_sin), expected)
+    assert_almost_equal(compute_spect_entropy(sfreq, data_sin,
+                                              psd_method='fft'), expected)
 
 
 def test_spect_edge_freq():
@@ -325,10 +331,12 @@ def test_spect_edge_freq():
     """
     expected = 5.
     assert_almost_equal(compute_spect_edge_freq(sfreq, data_sin, ref_freq=15,
-                                                edge=[50]), expected)
+                                                edge=[50], psd_method='fft'),
+                        expected)
     expected = 33.
     assert_almost_equal(compute_spect_edge_freq(sfreq, data_sin, ref_freq=50,
-                                                edge=[80]), expected)
+                                                edge=[80], psd_method='fft'),
+                        expected)
 
 
 def test_svd_entropy():

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -326,7 +326,7 @@ def test_spect_edge_freq():
 
     For `data_sin` (signal x(t) = 0.1 * sin(5t) + 0.05 * sin(33t), on
     [0, 2 * pi], at sfreq = 512Hz), the minimum frequency at which more than
-    50% (resp. 80%) of the spectral power up to ref_freq = 15Hz
+    50% (resp. 90%) of the spectral power up to ref_freq = 15Hz
     (resp. ref_freq = 50Hz) is contained in the signal is 5Hz (resp. 33HZ).
     """
     expected = 5.
@@ -335,7 +335,7 @@ def test_spect_edge_freq():
                         expected)
     expected = 33.
     assert_almost_equal(compute_spect_edge_freq(sfreq, data_sin, ref_freq=50,
-                                                edge=[80], psd_method='fft'),
+                                                edge=[90], psd_method='fft'),
                         expected)
 
 

--- a/mne_features/tests/test_utils.py
+++ b/mne_features/tests/test_utils.py
@@ -11,24 +11,31 @@ from mne_features.utils import _idxiter, power_spectrum, _embed, _filt
 
 
 rng = np.random.RandomState(42)
-sfreq = 256.
+sfreq = 172.
 data = rng.standard_normal((20, int(sfreq)))
 
 
-def test_power_spectrum():
-    ps, freqs = power_spectrum(sfreq, data, return_db=False)
-    _data = data - np.mean(data, axis=-1)[:, None]
-    assert_almost_equal(np.mean(_data ** 2, axis=-1), np.sum(ps, axis=-1))
-
-
 def test_psd():
-    n_times = data.shape[-1]
-    freqs, pxx = signal.welch(data, sfreq,
-                              window=signal.get_window('boxcar', n_times),
-                              return_onesided=True, scaling='spectrum')
-    ps, freqs2 = power_spectrum(sfreq, data, return_db=False)
-    assert_almost_equal(freqs, freqs2)
-    assert_almost_equal(pxx, ps)
+    n_channels, n_times = data.shape
+    _data = data[None, ...]
+    # Only test output shape when `method='welch'` or `method='multitaper'`
+    # since it is actually just a wrapper for MNE functions:
+    psd_welch, _ = power_spectrum(sfreq, _data, method='welch')
+    psd_multitaper, _ = power_spectrum(sfreq, _data, method='multitaper')
+    psd_fft, freqs_fft = power_spectrum(sfreq, _data, method='fft')
+    assert_equal(psd_welch.shape, (1, n_channels, n_times // 2 + 1))
+    assert_equal(psd_multitaper.shape, (1, n_channels, n_times // 2 + 1))
+    assert_equal(psd_fft.shape, (1, n_channels, n_times // 2 + 1))
+
+    # Compare result obtained with `method='fft'` to the Scipy's result
+    # (implementation of Welch's method with rectangular window):
+    expected_freqs, expected_psd = signal.welch(data, sfreq,
+                                                window=signal.get_window(
+                                                    'boxcar', data.shape[-1]),
+                                                return_onesided=True,
+                                                scaling='density')
+    assert_almost_equal(expected_freqs, freqs_fft)
+    assert_almost_equal(expected_psd, psd_fft[0, ...])
 
 
 def test_idxiter():
@@ -70,7 +77,6 @@ def test_filt():
 
 if __name__ == '__main__':
 
-    test_power_spectrum()
     test_psd()
     test_idxiter()
     test_embed()

--- a/mne_features/tests/test_utils.py
+++ b/mne_features/tests/test_utils.py
@@ -4,11 +4,11 @@
 
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 from scipy import signal
 
-from mne_features.utils import _idxiter, power_spectrum, _embed, _filt
-
+from mne_features.utils import (_idxiter, power_spectrum, _embed, _filt,
+                                _psd_params_checker)
 
 rng = np.random.RandomState(42)
 sfreq = 172.
@@ -75,9 +75,22 @@ def test_filt():
     assert_equal(filt_bandpass.shape, data.shape)
 
 
+def test_psd_params_checker():
+    valid_params = {'welch_n_fft': 2048, 'welch_n_per_seg': 1024}
+    assert_equal(valid_params, _psd_params_checker(valid_params))
+    assert_equal(dict(), _psd_params_checker(None))
+    with assert_raises(ValueError):
+        invalid_params1 = {'n_fft': 1024, 'psd_method': 'fft'}
+        _psd_params_checker(invalid_params1)
+    with assert_raises(ValueError):
+        invalid_params2 = [1024, 1024]
+        _psd_params_checker(invalid_params2)
+
+
 if __name__ == '__main__':
 
     test_psd()
     test_idxiter()
     test_embed()
     test_filt()
+    test_psd_params_checker()

--- a/mne_features/tests/test_utils.py
+++ b/mne_features/tests/test_utils.py
@@ -20,9 +20,9 @@ def test_psd():
     _data = data[None, ...]
     # Only test output shape when `method='welch'` or `method='multitaper'`
     # since it is actually just a wrapper for MNE functions:
-    psd_welch, _ = power_spectrum(sfreq, _data, method='welch')
-    psd_multitaper, _ = power_spectrum(sfreq, _data, method='multitaper')
-    psd_fft, freqs_fft = power_spectrum(sfreq, _data, method='fft')
+    psd_welch, _ = power_spectrum(sfreq, _data, psd_method='welch')
+    psd_multitaper, _ = power_spectrum(sfreq, _data, psd_method='multitaper')
+    psd_fft, freqs_fft = power_spectrum(sfreq, _data, psd_method='fft')
     assert_equal(psd_welch.shape, (1, n_channels, n_times // 2 + 1))
     assert_equal(psd_multitaper.shape, (1, n_channels, n_times // 2 + 1))
     assert_equal(psd_fft.shape, (1, n_channels, n_times // 2 + 1))

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -16,7 +16,7 @@ from sklearn.metrics import mean_squared_error, explained_variance_score
 
 from .mock_numba import nb
 from .utils import (power_spectrum, _embed, _filt, _get_feature_funcs,
-                    _wavelet_coefs, _idxiter)
+                    _wavelet_coefs, _idxiter, _psd_params_checker)
 
 
 def get_univariate_funcs(sfreq):
@@ -628,11 +628,9 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
         _freq_bands = np.asarray(freq_bands)
     fb = _freq_bands_helper(sfreq, _freq_bands)
     n_freq_bands = fb.shape[0]
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        psd, freqs = power_spectrum(sfreq, data, **psd_params)
-    else:
-        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method,
+                                **_psd_params)
     pow_freq_bands = np.empty((n_channels, n_freq_bands))
     for j in range(n_freq_bands):
         mask = np.logical_and(freqs >= fb[j, 0], freqs <= fb[j, 1])
@@ -729,11 +727,9 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
            studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        psd, freqs = power_spectrum(sfreq, data, **psd_params)
-    else:
-        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method,
+                                **_psd_params)
     w_freqs = np.power(freqs, 2)
     mobility = np.sum(np.multiply(psd, w_freqs), axis=-1)
     if normalize:
@@ -785,11 +781,9 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
            studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        psd, freqs = power_spectrum(sfreq, data, **psd_params)
-    else:
-        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method,
+                                **_psd_params)
     w_freqs = np.power(freqs, 4)
     complexity = np.sum(np.multiply(psd, w_freqs), axis=-1)
     if normalize:
@@ -1068,11 +1062,8 @@ def compute_spect_entropy(sfreq, data, psd_method='welch', psd_params=None):
            use of the entropy of the power spectrum. Electroencephalography
            and clinical neurophysiology, 79(3), 204-210.
     """
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        psd, _ = power_spectrum(sfreq, data, psd_method=psd_method)
-    else:
-        psd, _ = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    psd, _ = power_spectrum(sfreq, data, psd_method=psd_method, **_psd_params)
     m = np.sum(psd, axis=-1)
     psd_norm = np.divide(psd[:, 1:], m[:, None])
     return -np.sum(np.multiply(psd_norm, np.log2(psd_norm)), axis=-1)
@@ -1171,11 +1162,9 @@ def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
            Brain Functions (BBF).
     """
     n_channels = data.shape[0]
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        psd, freqs = power_spectrum(sfreq, data, **psd_params)
-    else:
-        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method,
+                                **_psd_params)
 
     # mask limiting to input freq_range
     mask = np.logical_and(freqs >= fmin, freqs <= fmax)
@@ -1371,11 +1360,9 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
     n_edge = len(_edge)
     n_channels, n_times = data.shape
     spect_edge_freq = np.empty((n_channels, n_edge))
-    if psd_params is not None:
-        psd_params.update({'psd_method': psd_method})
-        psd, freqs = power_spectrum(sfreq, data, **psd_params)
-    else:
-        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
+    _psd_params = _psd_params_checker(psd_params)
+    psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method,
+                                **_psd_params)
     out = np.cumsum(psd, 1)
     for i, p in enumerate(_edge):
         idx_ref = np.where(freqs >= _ref_freq)[0][0]

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -556,7 +556,8 @@ def _freq_bands_helper(sfreq, freq_bands):
 
 def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
                                                              30., 100.]),
-                           normalize=True, ratios=None, psd_method='welch'):
+                           normalize=True, ratios=None, psd_method='welch',
+                           psd_params=None):
     """Power Spectrum (computed by frequency bands).
 
     Parameters
@@ -596,6 +597,12 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
         Method used for the estimation of the Power Spectral Density (PSD).
         Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
 
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
+
     Returns
     -------
     output : ndarray, shape (n_channels * (n_freqs - 1),)
@@ -613,7 +620,11 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
     n_channels = data.shape[0]
     fb = _freq_bands_helper(sfreq, freq_bands)
     n_freq_bands = fb.shape[0]
-    psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        psd, freqs = power_spectrum(sfreq, data, **psd_params)
+    else:
+        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
     pow_freq_bands = np.empty((n_channels, n_freq_bands))
     for j in range(n_freq_bands):
         mask = np.logical_and(freqs >= fb[j, 0], freqs <= fb[j, 1])
@@ -639,7 +650,7 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
 
 
 def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
-                                  psd_method='welch'):
+                                  psd_method='welch', psd_params=None):
     """Hjorth mobility (per channel).
 
     Hjorth mobility parameter computed from the Power Spectrum of the data.
@@ -657,6 +668,12 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
     psd_method : str (default: 'welch')
         Method used for the estimation of the Power Spectral Density (PSD).
         Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
+
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
 
     Returns
     -------
@@ -676,7 +693,11 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
            studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
-    psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        psd, freqs = power_spectrum(sfreq, data, **psd_params)
+    else:
+        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
     w_freqs = np.power(freqs, 2)
     mobility = np.sum(np.multiply(psd, w_freqs), axis=-1)
     if normalize:
@@ -685,7 +706,7 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
 
 
 def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
-                                    psd_method='welch'):
+                                    psd_method='welch', psd_params=None):
     """Hjorth complexity (per channel).
 
     Hjorth complexity parameter computed from the Power Spectrum of the data.
@@ -703,6 +724,12 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
     psd_method : str (default: 'welch')
         Method used for the estimation of the Power Spectral Density (PSD).
         Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
+
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
 
     Returns
     -------
@@ -722,7 +749,11 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
            studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
-    psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        psd, freqs = power_spectrum(sfreq, data, **psd_params)
+    else:
+        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
     w_freqs = np.power(freqs, 4)
     complexity = np.sum(np.multiply(psd, w_freqs), axis=-1)
     if normalize:
@@ -964,7 +995,7 @@ def compute_line_length(data):
     return np.mean(np.abs(np.diff(data, axis=-1)), axis=-1)
 
 
-def compute_spect_entropy(sfreq, data, psd_method='welch'):
+def compute_spect_entropy(sfreq, data, psd_method='welch', psd_params=None):
     """Spectral Entropy (per channel).
 
     Spectral Entropy is defined to be the Shannon Entropy of the Power
@@ -981,6 +1012,12 @@ def compute_spect_entropy(sfreq, data, psd_method='welch'):
         Method used for the estimation of the Power Spectral Density (PSD).
         Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
 
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
+
     Returns
     -------
     output : ndarray, shape (n_channels,)
@@ -995,7 +1032,11 @@ def compute_spect_entropy(sfreq, data, psd_method='welch'):
            use of the entropy of the power spectrum. Electroencephalography
            and clinical neurophysiology, 79(3), 204-210.
     """
-    psd, _ = power_spectrum(sfreq, data, method=psd_method)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        psd, _ = power_spectrum(sfreq, data, method=psd_method)
+    else:
+        psd, _ = power_spectrum(sfreq, data, method=psd_method)
     m = np.sum(psd, axis=-1)
     psd_norm = np.divide(psd[:, 1:], m[:, None])
     return -np.sum(np.multiply(psd_norm, np.log2(psd_norm)), axis=-1)
@@ -1035,7 +1076,8 @@ def compute_svd_entropy(data, tau=2, emb=10):
 
 
 def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
-                        with_intercept=True, psd_method='welch'):
+                        with_intercept=True, psd_method='welch',
+                        psd_params=None):
     """Linear regression of the the log-log frequency-curve (per channel).
 
     Using a linear regression, the function estimates the slope and the
@@ -1066,6 +1108,12 @@ def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
         Method used for the estimation of the Power Spectral Density (PSD).
         Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
 
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
+
     Returns
     -------
     output : ndarray, shape (n_channels * 4,)
@@ -1087,7 +1135,11 @@ def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
            Brain Functions (BBF).
     """
     n_channels = data.shape[0]
-    psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        psd, freqs = power_spectrum(sfreq, data, **psd_params)
+    else:
+        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
 
     # mask limiting to input freq_range
     mask = np.logical_and(freqs >= fmin, freqs <= fmax)
@@ -1201,7 +1253,7 @@ def compute_energy_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8.,
 
 
 def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
-                            psd_method='welch'):
+                            psd_method='welch', psd_params=None):
     """Spectal Edge Frequency (per channel).
 
     Parameters
@@ -1225,6 +1277,12 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
     psd_method : str (default: 'welch')
         Method used for the estimation of the Power Spectral Density (PSD).
         Valid methods are: ``'welch'``, ``'multitaper'`` or ``'fft'``.
+
+    psd_params : dict or None (default: None)
+        If not None, dict with optional parameters (`welch_n_fft`,
+        `welch_n_per_seg`, `welch_n_overlap`) to be passed to
+        :func:`mne_features.utils.power_spectrum`. If None, default parameters
+        are used (see doc for :func:`mne_features.utils.power_spectrum`).
 
     Returns
     -------
@@ -1251,7 +1309,11 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
     n_edge = len(_edge)
     n_channels, n_times = data.shape
     spect_edge_freq = np.empty((n_channels, n_edge))
-    psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+    if psd_params is not None:
+        psd_params.update({'method': psd_method})
+        psd, freqs = power_spectrum(sfreq, data, **psd_params)
+    else:
+        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
     out = np.cumsum(psd, 1)
     for i, p in enumerate(_edge):
         idx_ref = np.where(freqs >= _ref_freq)[0][0]

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -657,7 +657,8 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
             return band_ratios.ravel()
 
 
-def _compute_pow_freq_bands_feat_names(data, freq_bands, normalize, ratios):
+def _compute_pow_freq_bands_feat_names(data, freq_bands, normalize, ratios,
+                                       psd_method, psd_params):
     """Utility function to create feature names compatible with the output
     of :func:`compute_pow_freq_bands`."""
     n_channels = data.shape[0]

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -621,10 +621,10 @@ def compute_pow_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8., 13.,
     fb = _freq_bands_helper(sfreq, freq_bands)
     n_freq_bands = fb.shape[0]
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
+        psd_params.update({'psd_method': psd_method})
         psd, freqs = power_spectrum(sfreq, data, **psd_params)
     else:
-        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
     pow_freq_bands = np.empty((n_channels, n_freq_bands))
     for j in range(n_freq_bands):
         mask = np.logical_and(freqs >= fb[j, 0], freqs <= fb[j, 1])
@@ -694,10 +694,10 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
            Neuroscience Methods, 200(2), 257-271.
     """
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
+        psd_params.update({'psd_method': psd_method})
         psd, freqs = power_spectrum(sfreq, data, **psd_params)
     else:
-        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
     w_freqs = np.power(freqs, 2)
     mobility = np.sum(np.multiply(psd, w_freqs), axis=-1)
     if normalize:
@@ -750,10 +750,10 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
            Neuroscience Methods, 200(2), 257-271.
     """
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
+        psd_params.update({'psd_method': psd_method})
         psd, freqs = power_spectrum(sfreq, data, **psd_params)
     else:
-        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
     w_freqs = np.power(freqs, 4)
     complexity = np.sum(np.multiply(psd, w_freqs), axis=-1)
     if normalize:
@@ -1033,10 +1033,10 @@ def compute_spect_entropy(sfreq, data, psd_method='welch', psd_params=None):
            and clinical neurophysiology, 79(3), 204-210.
     """
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
-        psd, _ = power_spectrum(sfreq, data, method=psd_method)
+        psd_params.update({'psd_method': psd_method})
+        psd, _ = power_spectrum(sfreq, data, psd_method=psd_method)
     else:
-        psd, _ = power_spectrum(sfreq, data, method=psd_method)
+        psd, _ = power_spectrum(sfreq, data, psd_method=psd_method)
     m = np.sum(psd, axis=-1)
     psd_norm = np.divide(psd[:, 1:], m[:, None])
     return -np.sum(np.multiply(psd_norm, np.log2(psd_norm)), axis=-1)
@@ -1136,10 +1136,10 @@ def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
     """
     n_channels = data.shape[0]
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
+        psd_params.update({'psd_method': psd_method})
         psd, freqs = power_spectrum(sfreq, data, **psd_params)
     else:
-        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
 
     # mask limiting to input freq_range
     mask = np.logical_and(freqs >= fmin, freqs <= fmax)
@@ -1310,10 +1310,10 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
     n_channels, n_times = data.shape
     spect_edge_freq = np.empty((n_channels, n_edge))
     if psd_params is not None:
-        psd_params.update({'method': psd_method})
+        psd_params.update({'psd_method': psd_method})
         psd, freqs = power_spectrum(sfreq, data, **psd_params)
     else:
-        psd, freqs = power_spectrum(sfreq, data, method=psd_method)
+        psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method)
     out = np.cumsum(psd, 1)
     for i, p in enumerate(_edge):
         idx_ref = np.where(freqs >= _ref_freq)[0][0]

--- a/mne_features/utils.py
+++ b/mne_features/utils.py
@@ -89,6 +89,7 @@ def _embed(x, d, tau):
 
 
 def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
+                   welch_n_fft=256, welch_n_per_seg=None, welch_n_overlap=0,
                    verbose=False):
     """Power Spectral Density (PSD).
 
@@ -117,6 +118,21 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
         the parameter ``method`` are: ``'welch'``, ``'fft'`` or
         ``'multitaper'``.
 
+    welch_n_fft : int (default: 256)
+        The length of the FFT used. The segments will be zero-padded if
+        `welch_n_fft > welch_n_per_seg`. This parameter will be ignored if
+        `method = 'fft'` or `method = 'multitaper'`.
+
+    welch_n_per_seg : int or None (default: None)
+        Length of each Welch segment (windowed with a Hamming window). If
+        None, `welch_n_per_seg` is equal to `welch_n_fft`. This parameter
+        will be ignored if `method = 'fft'` or `method = 'multitaper'`.
+
+    welch_n_overlap : int (default: 0)
+        The number of points of overlap between segments. Should be
+        `<= welch_n_per_seg`. This parameter will be ignored if
+        `method = 'fft'` or `method = 'multitaper'`.
+
     verbose : bool (default: False)
         Verbosity parameter. If True, info and warnings related to
         :func:`mne.time_frequency.psd_array_welch` or
@@ -133,10 +149,11 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
     _verbose = 40 * (1 - int(verbose))
     _fmin, _fmax = max(0, fmin), min(fmax, sfreq / 2)
     if method == 'welch':
-        n_fft = min(data.shape[-1], 2048)
+        _n_fft = min(data.shape[-1], welch_n_fft)
         return psd_array_welch(data, sfreq, fmin=_fmin, fmax=_fmax,
-                               n_fft=n_fft, verbose=_verbose,
-                               n_per_seg=n_fft, n_overlap=n_fft // 2)
+                               n_fft=_n_fft, verbose=_verbose,
+                               n_per_seg=welch_n_per_seg,
+                               n_overlap=welch_n_overlap)
     elif method == 'multitaper':
         return psd_array_multitaper(data, sfreq, fmin=_fmin, fmax=_fmax,
                                     verbose=_verbose)

--- a/mne_features/utils.py
+++ b/mne_features/utils.py
@@ -136,7 +136,7 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
         n_fft = min(data.shape[-1], 2048)
         return psd_array_welch(data, sfreq, fmin=_fmin, fmax=_fmax,
                                n_fft=n_fft, verbose=_verbose,
-                               n_per_seg=n_fft // 2, n_overlap=n_fft // 4)
+                               n_per_seg=n_fft, n_overlap=n_fft // 2)
     elif method == 'multitaper':
         return psd_array_multitaper(data, sfreq, fmin=_fmin, fmax=_fmax,
                                     verbose=_verbose)

--- a/mne_features/utils.py
+++ b/mne_features/utils.py
@@ -88,7 +88,7 @@ def _embed(x, d, tau):
     return X
 
 
-def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
+def power_spectrum(sfreq, data, fmin=0., fmax=256., psd_method='welch',
                    welch_n_fft=256, welch_n_per_seg=None, welch_n_overlap=0,
                    verbose=False):
     """Power Spectral Density (PSD).
@@ -113,7 +113,7 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
     fmax : float (default: 256.)
         Upper bound of the frequency range to consider.
 
-    method : str (default: 'welch')
+    psd_method : str (default: 'welch')
         Method used to estimate the PSD from the data. The valid values for
         the parameter ``method`` are: ``'welch'``, ``'fft'`` or
         ``'multitaper'``.
@@ -148,16 +148,16 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
     """
     _verbose = 40 * (1 - int(verbose))
     _fmin, _fmax = max(0, fmin), min(fmax, sfreq / 2)
-    if method == 'welch':
+    if psd_method == 'welch':
         _n_fft = min(data.shape[-1], welch_n_fft)
         return psd_array_welch(data, sfreq, fmin=_fmin, fmax=_fmax,
                                n_fft=_n_fft, verbose=_verbose,
                                n_per_seg=welch_n_per_seg,
                                n_overlap=welch_n_overlap)
-    elif method == 'multitaper':
+    elif psd_method == 'multitaper':
         return psd_array_multitaper(data, sfreq, fmin=_fmin, fmax=_fmax,
                                     verbose=_verbose)
-    elif method == 'fft':
+    elif psd_method == 'fft':
         n_times = data.shape[-1]
         m = np.mean(data, axis=-1)
         _data = data - m[..., None]
@@ -174,7 +174,7 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., method='welch',
     else:
         raise ValueError('The given method (%s) is not implemented. Valid '
                          'methods for the computation of the PSD are: '
-                         '`welch`, `fft` or `multitaper`.' % str(method))
+                         '`welch`, `fft` or `multitaper`.' % str(psd_method))
 
 
 def _filt(sfreq, data, filter_freqs, verbose=False):

--- a/mne_features/utils.py
+++ b/mne_features/utils.py
@@ -177,6 +177,40 @@ def power_spectrum(sfreq, data, fmin=0., fmax=256., psd_method='welch',
                          '`welch`, `fft` or `multitaper`.' % str(psd_method))
 
 
+def _psd_params_checker(params):
+    """Utility function to check parameters to be passed to `power_spectrum`.
+
+    Parameters
+    ----------
+    params : dict or None
+        Optional parameters to be passed to
+        :func:`mne_features.utils.power_spectrum`. If `params` contains a key
+        which is not an optional parameter of
+        :func:`mne_features.utils.power_spectrum`, an error is raised.
+
+    Returns
+    -------
+    valid_params : dict
+    """
+    if params is None:
+        return dict()
+    elif not isinstance(params, dict):
+        raise ValueError('The parameter `psd_params` has type %s. Expected '
+                         'dict instead.' % type(params))
+    else:
+        expected_keys = ['welch_n_fft', 'welch_n_per_seg', 'welch_n_overlap']
+        valid_keys = list()
+        for n in params:
+            if n not in expected_keys:
+                raise ValueError('The key %s in `psd_params` is not valid and '
+                                 'will be ignored. Valid keys are: %s' %
+                                 (n, str(expected_keys)))
+            else:
+                valid_keys.append(n)
+        valid_params = {n: params[n] for n in valid_keys}
+        return valid_params
+
+
 def _filt(sfreq, data, filter_freqs, verbose=False):
     """Filter data.
 


### PR DESCRIPTION
This PR aims at addressing #40 : the estimation of the PSD from the FFT of the data can sometimes be quite noisy. We propose to address that by allowing the PSD to be computed using Welch method (in case of "sufficiently large" windows, averaging should smooth the PSD a bit...), FFT or Multitaper.

The example below shows that using Welch method instead of the FFT can actually improve cross-validation classification scores (using ratios of band power as features).

Example:

```
import mne
import numpy as np
from mne.datasets import sample
from sklearn.linear_model import LogisticRegression
from sklearn.model_selection import cross_val_score, KFold
from sklearn.pipeline import Pipeline
from sklearn.base import clone
from sklearn.preprocessing import StandardScaler

from mne_features.feature_extraction import extract_features

###############################################################################
# Let us import the data using MNE-Python and epoch it:

data_path = sample.data_path()
raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
tmin, tmax = -0.2, 0.5
event_id = dict(aud_l=1, vis_l=3)

# Setup for reading the raw data
raw = mne.io.read_raw_fif(raw_fname, preload=True)
raw.filter(.5, None, fir_design='firwin')
events = mne.read_events(event_fname)
picks = mne.pick_types(raw.info, meg='grad', eeg=False)

# Read epochs
epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks, proj=True,
                    baseline=None, preload=True)
labels = epochs.events[:, -1]

# get MEG and EEG data
data = epochs.get_data()

###############################################################################
# Prepare for the classification task:
pipe = Pipeline([('scaler', StandardScaler()),
                 ('lr', LogisticRegression(random_state=42, solver='lbfgs'))])
y = labels

###############################################################################
# Cross-validation score using different methods to compute the PSD of the
# signal (FFT, Welch or Multitaper).

kf = KFold(n_splits=3, random_state=42)
selected_funcs = {'pow_freq_bands'}
selected_freq_bands = np.array([0.5, 4., 8., 13., 30., 70.])

for psd_method in ['fft', 'welch', 'multitaper']:

    X = extract_features(
        data, raw.info['sfreq'], selected_funcs,
        funcs_params={'pow_freq_bands__ratios': 'all',
                      'pow_freq_bands__freq_bands': selected_freq_bands,
                      'pow_freq_bands__psd_method': psd_method})
    scores = cross_val_score(clone(pipe), X, y, cv=kf)

    ###########################################################################
    # Print the cross-validation score:

    print('Cross-validation accuracy score with %s method = %1.3f '
          '(+/- %1.5f)' % (psd_method, np.mean(scores), np.std(scores)))
```
Outputs: 
```
Cross-validation accuracy score with fft method = 0.848 (+/- 0.02690)
Cross-validation accuracy score with welch method = 0.910 (+/- 0.02615)
Cross-validation accuracy score with multitaper method = 0.869 (+/- 0.05505)
```