### PR TITLE
Unexpected behavior of `edge` in `univariate.compute_spect_edge_freq`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,6 +134,7 @@ html_theme_options = {
     'navbar_links': [
         ("Examples", "auto_examples/index"),
         ("API", "api"),
+        ("What's new", "whats_new"),
         ("GitHub", "https://github.com/mne-tools/mne_features", True)
     ],
     'bootswatch_theme': "united"
@@ -193,7 +194,7 @@ html_favicon = 'logo/mne_features_logo.ico'
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,10 +25,11 @@ Cite
 
 Link to `PDF <https://hal.archives-ouvertes.fr/hal-01724272/>`_
 
-API
----
+More
+----
 
 .. toctree::
     :maxdepth: 1
 
     api.rst
+    whats_new.rst

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _whats_new:
 
 What's new?

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,0 +1,27 @@
+:orphan:
+
+.. _whats_new:
+
+What's new?
+===========
+
+.. currentmodule:: mne_features
+
+.. _current:
+
+Current
+-------
+
+Changelog
+~~~~~~~~~
+
+Bug
+~~~
+
+- Fixed the behavior of the `edge` parameter in :func:`mne_features.univariate.compute_spect_edge_freq`. Valid values for this parameter are now `None` or a list of float between `0` and `1` (percentages). By `Jean-Baptiste SCHIRATTI`_ in `#52 <https://github.com/mne-tools/mne-features/pull/52>`_.
+
+API
+~~~
+
+.. _Jean-Baptiste Schiratti: https://github.com/jbschiratti
+.. _Alex Gramfort: http://alexandre.gramfort.net

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -419,11 +419,11 @@ def test_spect_edge_freq():
     """
     expected = 5.
     assert_almost_equal(compute_spect_edge_freq(sfreq, data_sin, ref_freq=15,
-                                                edge=[50], psd_method='fft'),
+                                                edge=[.5], psd_method='fft'),
                         expected)
     expected = 33.
     assert_almost_equal(compute_spect_edge_freq(sfreq, data_sin, ref_freq=50,
-                                                edge=[90], psd_method='fft'),
+                                                edge=[.9], psd_method='fft'),
                         expected)
 
 

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -1313,11 +1313,8 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
         edge frequency. If None, `ref_freq = sfreq / 2` is used.
 
     edge : list of float or None (default: None)
-        If not None, the values of `edge` are assumed to be positive and will
-        be normalized to values between 0 and 1. Each entry of `edge`
-        corresponds to a percentage. The spectral edge frequency will be
-        computed for each different value in `edge`. If None, `edge = [0.5]`
-        is used.
+        If not None, ``edge`` is expected to be a list of values between 0
+        and 1. If None, ``edge = [0.5]`` is used.
 
     psd_method : str (default: 'welch')
         Method used for the estimation of the Power Spectral Density (PSD).
@@ -1350,7 +1347,12 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
     if edge is None:
         _edge = [0.5]
     else:
-        _edge = [e / 100. for e in edge]
+        # Check the values in `edge`
+        if not all([0 <= p <= 1 for p in edge]):
+            raise ValueError('The values in ``edge``` must be floats between '
+                             '0 and 1. Got {} instead.'.format(edge))
+        else:
+            _edge = edge
     n_edge = len(_edge)
     n_channels, n_times = data.shape
     spect_edge_freq = np.empty((n_channels, n_edge))


### PR DESCRIPTION
This PR is aimed at addressing #51 and fixing the documentation of `univariate.compute_spect_edge_freq` which was unclear.