### PR TITLE
Improving feature names 2

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,11 @@ Current
 Changelog
 ~~~~~~~~~
 
+Enhancements
+~~~~~~~~~~~~
+
+- Extended feature naming to all univariate functions. If no specific function is implemented for a given univariate function and that the output has the same shape as the input on the feature dimension, then a generic list of feature names is passed. Possibility to rename these feature by passing ``ch_names`` to :func:`mne_features.extract_features`. By `Paul ROUJANSKY`_ in `#60 <https://github.com/mne-tools/mne-features/pull/60>`_.
+
 Bug
 ~~~
 
@@ -23,3 +28,4 @@ API
 
 .. _Jean-Baptiste Schiratti: https://github.com/jbschiratti
 .. _Alex Gramfort: http://alexandre.gramfort.net
+.. _Paul Roujansky: https://github.com/paulroujansky

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -15,7 +15,7 @@ from sklearn.preprocessing import scale
 
 from .mock_numba import nb
 from .utils import (_idxiter, power_spectrum, _embed, _get_feature_funcs,
-                    _psd_params_checker)
+                    _get_feature_func_names, _psd_params_checker)
 
 
 def get_bivariate_funcs(sfreq):
@@ -31,6 +31,16 @@ def get_bivariate_funcs(sfreq):
     bivariate_funcs : dict
     """
     return _get_feature_funcs(sfreq, __name__)
+
+
+def get_bivariate_func_names():
+    """List of names of bivariate feature functions.
+
+    Returns
+    -------
+    bivariate_func_names : list
+    """
+    return _get_feature_func_names(__name__)
 
 
 @nb.jit([nb.float64[:](nb.float64, nb.float64[:, :], nb.optional(nb.boolean)),

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -179,7 +179,7 @@ def _format_as_dataframe(X, feature_names):
         return pd.DataFrame(data=X, columns=columns)
 
 
-def _apply_extractor(extractor, X, return_as_df):
+def _apply_extractor(extractor, X, ch_names, return_as_df):
     """Utility function to apply features extractor to ndarray X.
 
     Parameters
@@ -188,6 +188,8 @@ def _apply_extractor(extractor, X, return_as_df):
     :class:`~sklearn.pipeline.Pipeline`.
 
     X : ndarray, shape (n_channels, n_times)
+
+    ch_names : list of str or None
 
     return_as_df : bool
 
@@ -202,6 +204,12 @@ def _apply_extractor(extractor, X, return_as_df):
     feature_names = None
     if return_as_df:
         feature_names = extractor.get_feature_names()
+        if ch_names is not None:  # rename channels
+            mapping = {'ch%s' % i: ch_name
+                       for i, ch_name in enumerate(ch_names)}
+            for pattern, translation in mapping.items():
+                feature_names = [feature_name.replace(pattern, translation)
+                                 for feature_name in feature_names]
     return X, feature_names
 
 
@@ -370,7 +378,7 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
 
 
 def extract_features(X, sfreq, selected_funcs, funcs_params=None, n_jobs=1,
-                     return_as_df=False):
+                     ch_names=None, return_as_df=False):
     """Extraction of temporal or spectral features from epoched EEG signals.
 
     Parameters
@@ -407,6 +415,9 @@ def extract_features(X, sfreq, selected_funcs, funcs_params=None, n_jobs=1,
         Number of CPU cores used when parallelizing the feature extraction.
         If given a value of -1, all cores are used.
 
+    ch_names : list of str or None (default: None)
+        If not None, list containing the names of each input channel.
+
     return_as_df : bool (default: False)
         If True, the extracted features will be returned as a Pandas DataFrame.
         The column index is a MultiIndex (see :class:`~pandas.MultiIndex`)
@@ -425,6 +436,9 @@ def extract_features(X, sfreq, selected_funcs, funcs_params=None, n_jobs=1,
     feature_funcs.update(bivariate_funcs)
     sel_funcs = _check_funcs(selected_funcs, feature_funcs)
 
+    if ch_names is not None and len(ch_names) != X.shape[1]:
+        raise ValueError('`ch_names` should be of length {%s}' % X.shape[1])
+
     # Feature extraction
     n_epochs = X.shape[0]
     _tr = [(n, FeatureFunctionTransformer(func=func)) for n, func in sel_funcs]
@@ -432,7 +446,8 @@ def extract_features(X, sfreq, selected_funcs, funcs_params=None, n_jobs=1,
     if funcs_params is not None:
         extractor.set_params(**funcs_params)
     res = joblib.Parallel(n_jobs=n_jobs)(joblib.delayed(_apply_extractor)(
-        extractor, X[j, :, :], return_as_df) for j in range(n_epochs))
+        extractor, X[j, :, :], ch_names, return_as_df) for j in range(n_epochs)
+    )
     feature_names = res[0][1]
     res = list(zip(*res))[0]
     Xnew = np.vstack(res)

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -17,8 +17,8 @@ from sklearn.pipeline import FeatureUnion
 from sklearn.preprocessing import FunctionTransformer
 
 from .bivariate import get_bivariate_funcs
-from .univariate import get_univariate_funcs
-from .utils import _get_python_func
+from .univariate import get_univariate_funcs, get_univariate_func_names
+from .utils import _get_func_name, _get_python_func
 
 
 class FeatureFunctionTransformer(FunctionTransformer):
@@ -69,6 +69,12 @@ class FeatureFunctionTransformer(FunctionTransformer):
         """
         X_out = super(FeatureFunctionTransformer, self).transform(X)
         self.output_shape_ = X_out.shape[0]
+        if not hasattr(self, 'feature_names_'):
+            func_name = _get_func_name(self.func).replace('compute_', '')
+            if (func_name in get_univariate_func_names() and
+                    self.output_shape_ == X.shape[0]):
+                self.feature_names_ = ['ch%s' % ch
+                                       for ch in range(self.output_shape_)]
         return X_out
 
     def fit(self, X, y=None):

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -157,6 +157,21 @@ def test_user_defined_feature_function():
         extract_features(data, sfreq, ['mean', top_feature])
 
 
+def test_channel_naming():
+    ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
+    selected_funcs = ['app_entropy']
+    df = extract_features(
+        data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True)
+    expected_col_names = [('app_entropy', ch_name) for ch_name in ch_names]
+    assert df.columns.values.tolist() == expected_col_names
+
+    ch_names.append('CHANNEL%s' % (n_channels + 1))
+    with assert_raises(ValueError):
+        # incorrect number of channel names
+        df = extract_features(
+            data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True)
+
+
 if __name__ == '__main__':
 
     test_shape_output()
@@ -169,3 +184,4 @@ if __name__ == '__main__':
     test_gridsearch_feature_extractor()
     test_memory_feature_extractor()
     test_user_defined_feature_function()
+    test_channel_naming()

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -165,7 +165,7 @@ def test_channel_naming():
     expected_col_names = [('app_entropy', ch_name) for ch_name in ch_names]
     assert df.columns.values.tolist() == expected_col_names
 
-    ch_names.append('CHANNEL%s' % (n_channels + 1))
+    ch_names.append('CHANNEL%s' % n_channels)
     with assert_raises(ValueError):
         # incorrect number of channel names
         df = extract_features(

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -208,7 +208,7 @@ def test_generic_features_names():
     _data = data[:, :n_chans, :]
     selected_funcs = (
         ['mean', 'variance', 'std', 'ptp_amp', 'skewness', 'kurtosis',
-         'x²', 'app_entropy', 'samp_entropy', 'decorr_time',
+         'hurst_exp', 'app_entropy', 'samp_entropy', 'decorr_time',
          'hjorth_mobility_spect', 'hjorth_complexity_spect', 'hjorth_mobility',
          'hjorth_complexity', 'higuchi_fd', 'katz_fd', 'zero_crossings',
          'line_length', 'spect_entropy', 'svd_entropy', 'svd_fisher_info']

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -204,25 +204,25 @@ def test_pow_freq_bands():
 
 
 def test_generic_features_names():
-    n_chans = 2
-    _data = data[:, :n_chans, :]  # keep only 2 channels for the sake of simplicity
+    n_chans = 2  # keep only 2 channels for the sake of simplicity
+    _data = data[:, :n_chans, :]
     selected_funcs = (
         ['mean', 'variance', 'std', 'ptp_amp', 'skewness', 'kurtosis',
-         'hurst_exp', 'app_entropy', 'samp_entropy', 'decorr_time',
+         'x²', 'app_entropy', 'samp_entropy', 'decorr_time',
          'hjorth_mobility_spect', 'hjorth_complexity_spect', 'hjorth_mobility',
          'hjorth_complexity', 'higuchi_fd', 'katz_fd', 'zero_crossings',
          'line_length', 'spect_entropy', 'svd_entropy', 'svd_fisher_info']
     )
 
     col_names = [(func, 'ch%s' % ch)
-                 for func in selected_funcs for ch in range(n_chans) ]
+                 for func in selected_funcs for ch in range(n_chans)]
     df = extract_features(_data, sfreq, selected_funcs, return_as_df=True)
     assert df.columns.to_list() == col_names
 
 
 def test_feature_names_spect_edge_freq():
-    n_chans = 2
-    _data = data[:, :n_chans, :]  # keep only 2 channels for the sake of simplicity
+    n_chans = 2  # keep only 2 channels for the sake of simplicity
+    _data = data[:, :n_chans, :]
     selected_funcs = ['spect_edge_freq']
 
     _edges = [None, [.5], [.5, .9]]
@@ -240,8 +240,8 @@ def test_feature_names_spect_edge_freq():
 
 
 def test_feature_names_spect_slope():
-    n_chans = 2
-    _data = data[:, :n_chans, :]  # keep only 2 channels for the sake of simplicity
+    n_chans = 2  # keep only 2 channels for the sake of simplicity
+    _data = data[:, :n_chans, :]
     selected_funcs = ['spect_slope']
 
     stats = ['intercept', 'slope', 'MSE', 'R2']
@@ -253,8 +253,8 @@ def test_feature_names_spect_slope():
 
 
 def test_feature_names_wavelet_coef_energy(wavelet_name='db4'):
-    n_chans = 2
-    _data = data[:, :n_chans, :]  # keep only 2 channels for the sake of simplicity
+    n_chans = 2  # keep only 2 channels for the sake of simplicity
+    _data = data[:, :n_chans, :]
     selected_funcs = ['wavelet_coef_energy']
 
     # number of coefficients of the DWT
@@ -272,8 +272,8 @@ def test_feature_names_wavelet_coef_energy(wavelet_name='db4'):
 
 
 def test_feature_names_teager_kaiser_energy(wavelet_name='db4'):
-    n_chans = 2
-    _data = data[:, :n_chans, :]  # keep only 2 channels for the sake of simplicity
+    n_chans = 2  # keep only 2 channels for the sake of simplicity
+    _data = data[:, :n_chans, :]
     selected_funcs = ['teager_kaiser_energy']
 
     # number of coefficients of the DWT

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -34,6 +34,12 @@ def get_univariate_funcs(sfreq):
     return _get_feature_funcs(sfreq, __name__)
 
 
+def _compute_generic_feat_names(data, **kwargs):
+    """Utility function to create generic feature names given input shape."""
+    n_channels = data.shape[0]
+    return ['ch%s' % ch for ch in range(n_channels)]
+
+
 def _unbiased_autocorr(x, lags=50):
     """Unbiased autocorrelation function.
 
@@ -154,6 +160,9 @@ def compute_mean(data):
     return np.mean(data, axis=-1)
 
 
+compute_mean.get_feature_names = _compute_generic_feat_names
+
+
 def compute_variance(data):
     """Variance of the data (per channel).
 
@@ -170,6 +179,9 @@ def compute_variance(data):
     Alias of the feature function: **variance**
     """
     return np.var(data, axis=-1, ddof=1)
+
+
+compute_variance.get_feature_names = _compute_generic_feat_names
 
 
 def compute_std(data):
@@ -190,6 +202,9 @@ def compute_std(data):
     return np.std(data, axis=-1, ddof=1)
 
 
+compute_std.get_feature_names = _compute_generic_feat_names
+
+
 def compute_ptp_amp(data):
     """Peak-to-peak (PTP) amplitude of the data (per channel).
 
@@ -206,6 +221,9 @@ def compute_ptp_amp(data):
     Alias of the feature function: **ptp_amp**
     """
     return np.ptp(data, axis=-1)
+
+
+compute_ptp_amp.get_feature_names = _compute_generic_feat_names
 
 
 def compute_skewness(data):
@@ -227,6 +245,9 @@ def compute_skewness(data):
     return stats.skew(data, axis=ndim - 1)
 
 
+compute_skewness.get_feature_names = _compute_generic_feat_names
+
+
 def compute_kurtosis(data):
     """Kurtosis of the data (per channel).
 
@@ -244,6 +265,9 @@ def compute_kurtosis(data):
     """
     ndim = data.ndim
     return stats.kurtosis(data, axis=ndim - 1, fisher=False)
+
+
+compute_kurtosis.get_feature_names = _compute_generic_feat_names
 
 
 @nb.jit([nb.float64[:, :](nb.float64[:, :]),
@@ -354,6 +378,9 @@ def compute_hurst_exp(data):
     return hurst
 
 
+compute_hurst_exp.get_feature_names = _compute_generic_feat_names
+
+
 def _app_samp_entropy_helper(data, emb, metric='chebyshev',
                              approximate=True):
     """Utility function for `compute_app_entropy`` and `compute_samp_entropy`.
@@ -441,6 +468,9 @@ def compute_app_entropy(data, emb=2, metric='chebyshev'):
     return np.subtract(phi[:, 0], phi[:, 1])
 
 
+compute_app_entropy.get_feature_names = _compute_generic_feat_names
+
+
 def compute_samp_entropy(data, emb=2, metric='chebyshev'):
     """Sample Entropy (SampEn, per channel).
 
@@ -475,6 +505,9 @@ def compute_samp_entropy(data, emb=2, metric='chebyshev'):
         raise ValueError('Sample Entropy is not defined.')
     else:
         return -np.log(np.divide(phi[:, 1], phi[:, 0]))
+
+
+compute_samp_entropy.get_feature_names = _compute_generic_feat_names
 
 
 def compute_decorr_time(sfreq, data):
@@ -513,6 +546,9 @@ def compute_decorr_time(sfreq, data):
             decorr_time = -1
         decorrelation_times[j] = decorr_time
     return decorrelation_times
+
+
+compute_decorr_time.get_feature_names = _compute_generic_feat_names
 
 
 def _freq_bands_helper(sfreq, freq_bands):
@@ -737,6 +773,9 @@ def compute_hjorth_mobility_spect(sfreq, data, normalize=False,
     return mobility
 
 
+compute_hjorth_mobility_spect.get_feature_names = _compute_generic_feat_names
+
+
 def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
                                     psd_method='welch', psd_params=None):
     """Hjorth complexity (per channel).
@@ -791,6 +830,9 @@ def compute_hjorth_complexity_spect(sfreq, data, normalize=False,
     return complexity
 
 
+compute_hjorth_complexity_spect.get_feature_names = _compute_generic_feat_names
+
+
 def compute_hjorth_mobility(data):
     """Hjorth mobility (per channel).
 
@@ -822,6 +864,9 @@ def compute_hjorth_mobility(data):
     return mobility
 
 
+compute_hjorth_mobility.get_feature_names = _compute_generic_feat_names
+
+
 def compute_hjorth_complexity(data):
     """Hjorth complexity (per channel).
 
@@ -851,6 +896,9 @@ def compute_hjorth_complexity(data):
     m_x = compute_hjorth_mobility(data)
     complexity = np.divide(m_dx, m_x)
     return complexity
+
+
+compute_hjorth_complexity.get_feature_names = _compute_generic_feat_names
 
 
 @nb.jit([nb.float64[:](nb.float64[:, :], nb.int64),
@@ -929,6 +977,9 @@ def compute_higuchi_fd(data, kmax=10):
     return _higuchi_fd(data, kmax)
 
 
+compute_higuchi_fd.get_feature_names = _compute_generic_feat_names
+
+
 def compute_katz_fd(data):
     """Katz Fractal Dimension (per channel).
 
@@ -958,6 +1009,9 @@ def compute_katz_fd(data):
     d = np.max(np.abs(aux_d[:, 1:]), axis=-1)
     katz = np.divide(ln, np.add(ln, np.log10(np.divide(d, ll))))
     return katz
+
+
+compute_katz_fd.get_feature_names = _compute_generic_feat_names
 
 
 def compute_zero_crossings(data, threshold=np.finfo(np.float64).eps):
@@ -995,6 +1049,9 @@ def compute_zero_crossings(data, threshold=np.finfo(np.float64).eps):
     return count
 
 
+compute_zero_crossings.get_feature_names = _compute_generic_feat_names
+
+
 def compute_line_length(data):
     """Line length (per channel).
 
@@ -1018,6 +1075,9 @@ def compute_line_length(data):
            Conference of the IEEE (Vol. 2, pp. 1707-1710). IEEE.
     """
     return np.mean(np.abs(np.diff(data, axis=-1)), axis=-1)
+
+
+compute_line_length.get_feature_names = _compute_generic_feat_names
 
 
 def compute_spect_entropy(sfreq, data, psd_method='welch', psd_params=None):
@@ -1064,6 +1124,9 @@ def compute_spect_entropy(sfreq, data, psd_method='welch', psd_params=None):
     return -np.sum(np.multiply(psd_norm, np.log2(psd_norm)), axis=-1)
 
 
+compute_spect_entropy.get_feature_names = _compute_generic_feat_names
+
+
 def compute_svd_entropy(data, tau=2, emb=10):
     """SVD entropy (per channel).
 
@@ -1095,6 +1158,9 @@ def compute_svd_entropy(data, tau=2, emb=10):
     m = np.sum(sv, axis=-1)
     sv_norm = np.divide(sv, m[:, None])
     return -np.sum(np.multiply(sv_norm, np.log2(sv_norm)), axis=-1)
+
+
+compute_svd_entropy.get_feature_names = _compute_generic_feat_names
 
 
 def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
@@ -1182,6 +1248,18 @@ def compute_spect_slope(sfreq, data, fmin=0.1, fmax=50,
     return fit_info.ravel()
 
 
+def _compute_spect_slope_feat_names(data, **kwargs):
+    """Utility function to create feature names compatible with the output of
+    :func:`mne_features.univariate.compute_energy_freq_bands`."""
+    n_channels = data.shape[0]
+    stats = ['intercept', 'slope', 'MSE', 'R2']
+    return ['ch%s_%s' % (ch, stat) for ch in range(n_channels)
+            for stat in stats]
+
+
+compute_spect_slope.get_feature_names = _compute_spect_slope_feat_names
+
+
 def compute_svd_fisher_info(data, tau=2, emb=10):
     """SVD Fisher Information (per channel).
 
@@ -1214,6 +1292,9 @@ def compute_svd_fisher_info(data, tau=2, emb=10):
     sv_norm = np.divide(sv, m[:, None])
     aux = np.divide(np.diff(sv_norm, axis=-1) ** 2, sv_norm[:, :-1])
     return np.sum(aux, axis=-1)
+
+
+compute_svd_fisher_info.get_feature_names = _compute_generic_feat_names
 
 
 def compute_energy_freq_bands(sfreq, data, freq_bands=np.array([0.5, 4., 8.,
@@ -1291,8 +1372,8 @@ def _compute_energy_fb_feat_names(data, freq_bands, deriv_filt):
         n_freq_bands = (freq_bands.shape[0] - 1 if freq_bands.ndim == 1
                         else freq_bands.shape[0])
         _band_names = ['band' + str(j) for j in range(n_freq_bands)]
-    return ['ch%s_%s' % (ch, _band_names[i]) for ch in range(n_channels) for
-            i in range(n_freq_bands)]
+    return ['ch%s_%s' % (ch, _band_names[i]) for ch in range(n_channels)
+            for i in range(n_freq_bands)]
 
 
 compute_energy_freq_bands.get_feature_names = _compute_energy_fb_feat_names
@@ -1355,7 +1436,7 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
         else:
             _edge = edge
     n_edge = len(_edge)
-    n_channels, n_times = data.shape
+    n_channels = data.shape[0]
     spect_edge_freq = np.empty((n_channels, n_edge))
     _psd_params = _psd_params_checker(psd_params)
     psd, freqs = power_spectrum(sfreq, data, psd_method=psd_method,
@@ -1371,6 +1452,27 @@ def compute_spect_edge_freq(sfreq, data, ref_freq=None, edge=None,
             else:
                 spect_edge_freq[j, i] = -1
     return spect_edge_freq.ravel()
+
+
+def _compute_spect_edge_freq_feat_names(data, edge, **kwargs):
+    """Utility function to create feature names compatible with the output of
+    :func:`mne_features.univariate.compute_spect_edge_freq`."""
+    n_channels = data.shape[0]
+    if edge is None:
+        _edge = [0.5]
+    else:
+        # Check the values in `edge`
+        if not all([0 <= p <= 1 for p in edge]):
+            raise ValueError('The values in ``edge``` must be floats between '
+                             '0 and 1. Got {} instead.'.format(edge))
+        else:
+            _edge = edge
+    n_edges = len(_edge)
+    return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
+            for i in range(n_edges)]
+
+
+compute_spect_edge_freq.get_feature_names = _compute_spect_edge_freq_feat_names
 
 
 def compute_wavelet_coef_energy(data, wavelet_name='db4'):
@@ -1402,7 +1504,7 @@ def compute_wavelet_coef_energy(data, wavelet_name='db4'):
            studies on the prediction of epileptic seizures. Journal of
            Neuroscience Methods, 200(2), 257-271.
     """
-    n_channels, n_times = data.shape
+    n_channels = data.shape[0]
     coefs = _wavelet_coefs(data, wavelet_name)
     levdec = len(coefs) - 1
     wavelet_energy = np.zeros((n_channels, levdec))
@@ -1410,6 +1512,20 @@ def compute_wavelet_coef_energy(data, wavelet_name='db4'):
         for level in range(levdec):
             wavelet_energy[j, level] = np.sum(coefs[levdec - level][j, :] ** 2)
     return wavelet_energy.ravel()
+
+
+def _compute_wavelet_coef_energy_feat_names(data, wavelet_name, **kwargs):
+    """Utility function to create feature names compatible with the output of
+    :func:`mne_features.univariate.compute_wavelet_coef_energy`."""
+    n_channels = data.shape[0]
+    coefs = _wavelet_coefs(data, wavelet_name)
+    levdec = len(coefs) - 1
+    return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
+            for i in range(levdec)]
+
+
+compute_wavelet_coef_energy.get_feature_names = \
+    _compute_wavelet_coef_energy_feat_names
 
 
 @nb.jit([nb.float64[:, :](nb.float64[:, :]),
@@ -1461,7 +1577,7 @@ def compute_teager_kaiser_energy(data, wavelet_name='db4'):
            wavelet transform and Teager-Kaiser energy operator. In Calcutta
            Conference (CALCON). 2017 IEEE (pp. 164-167).
     """
-    n_channels, n_times = data.shape
+    n_channels = data.shape[0]
     coefs = _wavelet_coefs(data, wavelet_name)
     levdec = len(coefs) - 1
     tke = np.empty((n_channels, levdec + 1, 2))
@@ -1470,3 +1586,17 @@ def compute_teager_kaiser_energy(data, wavelet_name='db4'):
         tke[:, level, 0] = np.mean(tk_energy, axis=-1)
         tke[:, level, 1] = np.std(tk_energy, ddof=1, axis=-1)
     return tke.ravel()
+
+
+def _compute_teager_kaiser_energy_feat_names(data, wavelet_name, **kwargs):
+    """Utility function to create feature names compatible with the output of
+    :func:`mne_features.univariate.compute_teager_kaiser_energy`."""
+    n_channels = data.shape[0]
+    coefs = _wavelet_coefs(data, wavelet_name)
+    levdec = len(coefs) - 1
+    return ['ch%s_%s_%s' % (ch, i, stat) for ch in range(n_channels)
+            for i in range(levdec + 1) for stat in ['mean', 'std']]
+
+
+compute_teager_kaiser_energy.get_feature_names = \
+    _compute_teager_kaiser_energy_feat_names

--- a/mne_features/utils.py
+++ b/mne_features/utils.py
@@ -254,6 +254,30 @@ def _filt(sfreq, data, filter_freqs, verbose=False):
                            fir_design='firwin', verbose=_verbose)
 
 
+def _get_feature_func_names(module_name):
+    """Inspection for names of feature functions.
+
+    Inspects a given module and returns a list of the names of the feature
+    functions in this module. If the module does not contain any feature
+    function, an empty list is returned.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of the module to inspect.
+
+    Returns
+    -------
+    feature_func_names : list
+    """
+    feature_func_names = []
+    res = getmembers(sys.modules[module_name], isfunction)
+    for name, _ in res:
+        if name.startswith('compute_'):
+            feature_func_names.append(name.split('compute_')[-1])
+    return feature_func_names
+
+
 def _get_feature_funcs(sfreq, module_name):
     """Inspection for feature functions.
 
@@ -336,3 +360,23 @@ def _wavelet_coefs(data, wavelet_name='db4'):
     levdec = min(pywt.dwt_max_level(data.shape[-1], wavelet.dec_len), 6)
     coefs = pywt.wavedec(data, wavelet=wavelet, level=levdec)
     return coefs
+
+
+def _get_func_name(func):
+    """Return the name of input function.
+
+    Parameters
+    ----------
+    func : callable
+        Input function.
+
+    Returns
+    -------
+    func_name : str
+        Name of the input function.
+
+    """
+    if isinstance(func, partial):
+        return func.func.__name__
+    else:
+        return func.__name__


### PR DESCRIPTION
## Description
In the light of the changes made in PR https://github.com/mne-tools/mne-features/pull/42 related to having more meaningful feature names when `extract_features` is called with `return_df = True`, I extended the mechanism to every univariate functions, as most of them didn't implement a `get_feature_names` method.

In order to do so, I added a very basic `_compute_generic_feat_names` function that returns a list `[ch0, ch1, ...]` (given input channel dim).
In addition to that, I added specific feature naming functions to the following metrics:
- `spect_edge_freq`
- `spect_slope`
- `wavelet_coef_energy`
- `teager_kaiser_energy`

As a consequence, the columns of the resulting dataframe are a bit more intelligible.
In addition to that, I added the possibility to pass the list of channel names when calling `extract_features` in order to translate these directly in the columns.

**Example:**
```python
from mne_features.feature_extraction import extract_features
import numpy as np

data = np.random.random((5, 2, 500))

extract_features(data,
                 sfreq=250,
                 selected_funcs=['app_entropy', 'hurst_exp'],
                 ch_names=['PO3', 'PO4'],
                 return_as_df=True)
```
outputs
<p align="center">
<img src="https://user-images.githubusercontent.com/25418156/96237673-e323fa00-0f9d-11eb-8e2c-0ca25647bb07.png" width="280"/>
</p>

I added some tests to check these new functionnalities.
