### PR TITLE
[WIP] Adding parameters log and ratios_triu to compute_pow_freq_bands

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,6 +17,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 - Extended feature naming to all univariate functions. If no specific function is implemented for a given univariate function and that the output has the same shape as the input on the feature dimension, then a generic list of feature names is passed. Possibility to rename these feature by passing ``ch_names`` to :func:`mne_features.extract_features`. By `Paul ROUJANSKY`_ in `#60 <https://github.com/mne-tools/mne-features/pull/60>`_.
+- Added ``log`` and ``ratios_triu`` to :func:`mne_features.univariate.compute_pow_freq_bands` to allow computing log-power and log-ratios of power and controlling whether all possible band ratios should be computed.  By `Hubert Banville`_ in `#62 <https://github.com/mne-tools/mne-features/pull/62>`_.
 
 Bug
 ~~~
@@ -29,3 +30,4 @@ API
 .. _Jean-Baptiste Schiratti: https://github.com/jbschiratti
 .. _Alex Gramfort: http://alexandre.gramfort.net
 .. _Paul Roujansky: https://github.com/paulroujansky
+.. _Hubert Banville: https: https://hubertjb.github.io/

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -218,16 +218,18 @@ def test_pow_freq_bands_ratios():
     fb = np.array([[4., 8.], [30., 70.]])
     expected_pow = np.array([0.005, 0.00125]) / 0.00625
     expected_ratios = np.array([4., 0.25])
-    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
-                                               ratios='all', psd_method='fft'),
-                        np.r_[expected_pow, expected_ratios])
-    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
-                                               ratios='only', psd_method='fft'),
-                        expected_ratios)
-    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
-                                               ratios='only', ratios_triu=True,
-                                               psd_method='fft'),
-                        expected_ratios[[0]])
+    assert_almost_equal(
+        compute_pow_freq_bands(
+            sfreq, data_sin, freq_bands=fb, ratios='all', psd_method='fft'),
+        np.r_[expected_pow, expected_ratios])
+    assert_almost_equal(
+        compute_pow_freq_bands(
+            sfreq, data_sin, freq_bands=fb, ratios='only', psd_method='fft'),
+        expected_ratios)
+    assert_almost_equal(
+        compute_pow_freq_bands(
+            sfreq, data_sin, freq_bands=fb, ratios='only', ratios_triu=True,
+            psd_method='fft'), expected_ratios[[0]])
 
     with assert_raises(ValueError):
         # Invalid `ratios` parameter
@@ -242,13 +244,13 @@ def test_pow_freq_bands_log_ratios():
     expected_pow = np.log10(np.array([0.005, 0.00125]))
     expected_ratios = np.log10(np.array([4., 0.25]))
     assert_almost_equal(
-        compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb, normalize=False,
-                               ratios='all', psd_method='fft', log=True),
-                        np.r_[expected_pow, expected_ratios])
+        compute_pow_freq_bands(
+            sfreq, data_sin, freq_bands=fb, normalize=False, ratios='all',
+            psd_method='fft', log=True), np.r_[expected_pow, expected_ratios])
     assert_almost_equal(
-        compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb, normalize=False,
-                               ratios='only', psd_method='fft', log=True),
-                        expected_ratios)
+        compute_pow_freq_bands(
+            sfreq, data_sin, freq_bands=fb, normalize=False, ratios='only',
+            psd_method='fft', log=True), expected_ratios)
 
 
 def test_generic_features_names():

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -181,10 +181,37 @@ def test_freq_bands_helper():
         _freq_bands_helper(256., fb2.T)
 
 
-def test_pow_freq_bands():
+def test_pow_freq_bands_norm():
     expected = np.array([0, 0.005, 0, 0, 0.00125]) / 0.00625
-    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin,
-                                               psd_method='fft'), expected)
+    assert_almost_equal(
+        compute_pow_freq_bands(sfreq, data_sin, normalize=True,
+                               psd_method='fft'), expected)
+
+
+def test_pow_freq_bands_no_norm():
+    expected = np.array([0, 0.005, 0, 0, 0.00125])
+    assert_almost_equal(
+        compute_pow_freq_bands(sfreq, data_sin, normalize=False,
+                               psd_method='fft'), expected)
+
+
+def test_pow_freq_bands_norm_log():
+    expected = np.array([-5317.19500282, -368.16479931, -5247.13240494,
+                         -5146.55896452, -464.49439792])
+    assert_almost_equal(
+        compute_pow_freq_bands(sfreq, data_sin, normalize=True, log=True,
+                               psd_method='fft'), expected)
+
+
+def test_pow_freq_bands_no_norm_log():
+    expected = np.array([-33.23246877, -2.30103, -32.79457753, -32.16599353,
+                         -2.90308999])
+    assert_almost_equal(
+        compute_pow_freq_bands(sfreq, data_sin, normalize=False, log=True,
+                               psd_method='fft'), expected)
+
+
+def test_pow_freq_bands_ratios():
     # Ratios of power in bands:
     # For data_sin, only the usual theta (4Hz - 8Hz) and low gamma
     # (30Hz - 70Hz) bands contain non-zero power.
@@ -195,12 +222,33 @@ def test_pow_freq_bands():
                                                ratios='all', psd_method='fft'),
                         np.r_[expected_pow, expected_ratios])
     assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
-                                               ratios='only',
-                                               psd_method='fft'),
+                                               ratios='only', psd_method='fft'),
                         expected_ratios)
+    assert_almost_equal(compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb,
+                                               ratios='only', ratios_triu=True,
+                                               psd_method='fft'),
+                        expected_ratios[[0]])
+
     with assert_raises(ValueError):
         # Invalid `ratios` parameter
         compute_pow_freq_bands(sfreq, data_sin, ratios=['alpha', 'beta'])
+
+
+def test_pow_freq_bands_log_ratios():
+    # Log ratios of power in bands:
+    # For data_sin, only the usual theta (4Hz - 8Hz) and low gamma
+    # (30Hz - 70Hz) bands contain non-zero power.
+    fb = np.array([[4., 8.], [30., 70.]])
+    expected_pow = np.log10(np.array([0.005, 0.00125]))
+    expected_ratios = np.log10(np.array([4., 0.25]))
+    assert_almost_equal(
+        compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb, normalize=False,
+                               ratios='all', psd_method='fft', log=True),
+                        np.r_[expected_pow, expected_ratios])
+    assert_almost_equal(
+        compute_pow_freq_bands(sfreq, data_sin, freq_bands=fb, normalize=False,
+                               ratios='only', psd_method='fft', log=True),
+                        expected_ratios)
 
 
 def test_generic_features_names():
@@ -331,6 +379,16 @@ def test_feature_names_pow_freq_bands():
                           'pow_freq_bands__freq_bands': fb},
             return_as_df=True)
         assert_equal(df.columns.get_level_values(1).values, pow_names)
+
+        # With `ratios = 'only'` and `ratios_triu = True`:
+        df_only = extract_features(
+            _data, sfreq, selected_funcs,
+            funcs_params={'pow_freq_bands__ratios': 'only',
+                          'pow_freq_bands__ratios_triu': True,
+                          'pow_freq_bands__freq_bands': fb},
+            return_as_df=True)
+        assert_equal(df_only.columns.get_level_values(1).values,
+                     ratios_names[::2])
 
 
 def test_hjorth_mobility_spect():
@@ -552,7 +610,12 @@ if __name__ == '__main__':
     test_samp_entropy()
     test_decorr_time()
     test_freq_bands_helper()
-    test_pow_freq_bands()
+    test_pow_freq_bands_norm()
+    test_pow_freq_bands_no_norm()
+    test_pow_freq_bands_norm_log()
+    test_pow_freq_bands_no_norm_log()
+    test_pow_freq_bands_ratios()
+    test_pow_freq_bands_log_ratios()
     test_feature_names_pow_freq_bands()
     test_hjorth_mobility_spect()
     test_hjorth_complexity_spect()


### PR DESCRIPTION
This PR introduces parameters `log` and `ratios_triu` to `compute_pow_freq_bands` (again, if there's interest in including this in the library!). This one might require some discussion.

`log` controls whether the power is log-transformed. If `log=True`, the band ratios are calculated as "log-ratios" (e.g., log(alpha_pow/beta_pow)). Since this then leads to a linear relationship between a log-ratio an its log-inverse ratio (i.e., log(alpha_pow/beta_pow) = -1 * log(beta_pow/alpha_pow)), I added an additional parameter, `ratios_triu` which controls whether we should compute all possible pairs (which is currently the default behaviour) or only the upper part of the matrix of possible pairs. I included tests for the different scenarios, and ended up dividing the test for `compute_pow_freq_bands` into a couple smaller ones.