### PR TITLE
[WIP] Improvements to feature naming

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,13 +18,13 @@ Enhancements
 
 - Extended feature naming to all univariate functions. If no specific function is implemented for a given univariate function and that the output has the same shape as the input on the feature dimension, then a generic list of feature names is passed. Possibility to rename these feature by passing ``ch_names`` to :func:`mne_features.extract_features`. By `Paul ROUJANSKY`_ in `#60 <https://github.com/mne-tools/mne-features/pull/60>`_.
 - Added ``log`` and ``ratios_triu`` to :func:`mne_features.univariate.compute_pow_freq_bands` to allow computing log-power and log-ratios of power and controlling whether all possible band ratios should be computed.  By `Hubert Banville`_ in `#62 <https://github.com/mne-tools/mne-features/pull/62>`_.
-- Extended feature naming to all bivariate functions, with the same option to pass ``ch_names``  to :func:`mne_features.extract_features` as for univariate functions. By `Hubert Banville`_ in `#52 <https://github.com/mne-tools/mne-features/pull/63>`_.
+- Extended feature naming to all bivariate functions, with the same option to pass ``ch_names``  to :func:`mne_features.extract_features` as for univariate functions. By `Hubert Banville`_ in `#63 <https://github.com/mne-tools/mne-features/pull/63>`_.
 
 Bug
 ~~~
 
 - Fixed the behavior of the `edge` parameter in :func:`mne_features.univariate.compute_spect_edge_freq`. Valid values for this parameter are now `None` or a list of float between `0` and `1` (percentages). By `Jean-Baptiste SCHIRATTI`_ in `#52 <https://github.com/mne-tools/mne-features/pull/52>`_.
-- Fixed channel name replacement with overlapping channel names (e.g., Cz and FCz) in :func:`mne_features.feature_extraction._apply_extractor`. By `Hubert Banville`_ in `#52 <https://github.com/mne-tools/mne-features/pull/63>`_.
+- Fixed channel name replacement with overlapping channel names (e.g., Cz and FCz) which affected :func:`mne_features.extract_features` with `return_as_df=True` and when `ch_names` are provided. By `Hubert Banville`_ in `#63 <https://github.com/mne-tools/mne-features/pull/63>`_.
 
 API
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,11 +18,13 @@ Enhancements
 
 - Extended feature naming to all univariate functions. If no specific function is implemented for a given univariate function and that the output has the same shape as the input on the feature dimension, then a generic list of feature names is passed. Possibility to rename these feature by passing ``ch_names`` to :func:`mne_features.extract_features`. By `Paul ROUJANSKY`_ in `#60 <https://github.com/mne-tools/mne-features/pull/60>`_.
 - Added ``log`` and ``ratios_triu`` to :func:`mne_features.univariate.compute_pow_freq_bands` to allow computing log-power and log-ratios of power and controlling whether all possible band ratios should be computed.  By `Hubert Banville`_ in `#62 <https://github.com/mne-tools/mne-features/pull/62>`_.
+- Extended feature naming to all bivariate functions, with the same option to pass ``ch_names``  to :func:`mne_features.extract_features` as for univariate functions. By `Hubert Banville`_ in `#52 <https://github.com/mne-tools/mne-features/pull/63>`_.
 
 Bug
 ~~~
 
 - Fixed the behavior of the `edge` parameter in :func:`mne_features.univariate.compute_spect_edge_freq`. Valid values for this parameter are now `None` or a list of float between `0` and `1` (percentages). By `Jean-Baptiste SCHIRATTI`_ in `#52 <https://github.com/mne-tools/mne-features/pull/52>`_.
+- Fixed channel name replacement with overlapping channel names (e.g., Cz and FCz) in :func:`mne_features.feature_extraction._apply_extractor`. By `Hubert Banville`_ in `#52 <https://github.com/mne-tools/mne-features/pull/63>`_.
 
 API
 ~~~

--- a/mne_features/bivariate.py
+++ b/mne_features/bivariate.py
@@ -314,6 +314,20 @@ def compute_time_corr(data, with_eigenvalues=True, include_diag=False):
         return coefs
 
 
+def _compute_eig_feat_names(data, with_eigenvalues, include_diag, **kwargs):
+    """Utility function to create feature names compatible with the output of
+    :func:`mne_features.bivariate.compute_time_corr` and
+    :func:`mne_features.bivariate.compute_spect_corr`."""
+    feat_names = [f'ch{i}-ch{j}' for _, i, j, in _idxiter(
+                  data.shape[0], include_diag=include_diag)]
+    if with_eigenvalues:
+        feat_names.extend([f'eig{i}' for i in range(data.shape[0])])
+    return feat_names
+
+
+compute_time_corr.get_feature_names = _compute_eig_feat_names
+
+
 def compute_spect_corr(sfreq, data, with_eigenvalues=True,
                        include_diag=False, psd_method='welch',
                        psd_params=None):
@@ -377,3 +391,6 @@ def compute_spect_corr(sfreq, data, with_eigenvalues=True,
         return np.r_[coefs, w]
     else:
         return coefs
+
+
+compute_spect_corr.get_feature_names = _compute_eig_feat_names

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -227,7 +227,7 @@ def _apply_extractor(extractor, X, ch_names, return_as_df):
                 feature_names = [
                     re.sub(pattern=rf'{pattern}(?=_)|{pattern}\b',
                            string=feature_name, repl=translation)
-                           for feature_name in feature_names]
+                    for feature_name in feature_names]
 
     return X, feature_names
 

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -213,7 +213,7 @@ def test_channel_naming_bivariate(selected_func, include_diag):
 
 @pytest.mark.parametrize('selected_func', ['time_corr', 'spect_corr'])
 @pytest.mark.parametrize('include_diag', [True, False])
-@pytest.mark.parametrize('with_eig', [True,False])
+@pytest.mark.parametrize('with_eig', [True, False])
 def test_channel_naming_bivariate_eig(selected_func, include_diag, with_eig):
     ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
     ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -5,6 +5,7 @@
 
 from tempfile import mkdtemp
 
+import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_raises, assert_almost_equal
 from sklearn.model_selection import GridSearchCV
@@ -18,6 +19,8 @@ from mne_features.feature_extraction import (extract_features,
                                              FeatureExtractor)
 from mne_features.mock_numba import nb
 from mne_features.univariate import compute_svd_fisher_info
+from mne_features.utils import _idxiter
+
 
 rng = np.random.RandomState(42)
 sfreq = 256.
@@ -159,6 +162,7 @@ def test_user_defined_feature_function():
 
 def test_channel_naming():
     ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
     selected_funcs = ['app_entropy']
     df = extract_features(
         data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True)
@@ -170,6 +174,64 @@ def test_channel_naming():
         # incorrect number of channel names
         df = extract_features(
             data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True)
+
+
+def test_channel_naming_pow_freq_bands():
+    ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    selected_funcs = ['pow_freq_bands']
+    func_params = {
+        'pow_freq_bands__freq_bands': np.array([[0, 2], [10, 20]]),
+        'pow_freq_bands__ratios': 'only'
+    }
+    df = extract_features(
+        data, sfreq, selected_funcs, func_params, ch_names=ch_names,
+        return_as_df=True)
+
+    expected_col_names = [
+        ('pow_freq_bands', f'{ch_name}_band{i}/band{j}')
+        for ch_name in ch_names for _, i, j in _idxiter(2, triu=False)]
+    assert df.columns.values.tolist() == expected_col_names
+
+
+@pytest.mark.parametrize('selected_func', ['max_cross_corr', 'phase_lock_val',
+                                           'nonlin_interdep'])
+@pytest.mark.parametrize('include_diag', [True, False])
+def test_channel_naming_bivariate(selected_func, include_diag):
+    ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    func_params = {selected_func + '__include_diag': include_diag}
+    df = extract_features(
+        data, sfreq, [selected_func], func_params, ch_names=ch_names,
+        return_as_df=True)
+    expected_col_names = [
+        (selected_func, ch_names[i] + '-' + ch_names[j])
+        for s, i, j in _idxiter(n_channels, include_diag=include_diag)]
+
+    assert df.columns.values.tolist() == expected_col_names
+
+
+@pytest.mark.parametrize('selected_func', ['time_corr', 'spect_corr'])
+@pytest.mark.parametrize('include_diag', [True, False])
+@pytest.mark.parametrize('with_eig', [True,False])
+def test_channel_naming_bivariate_eig(selected_func, include_diag, with_eig):
+    ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    func_params = {
+        selected_func + '__include_diag': include_diag,
+        selected_func + '__with_eigenvalues': with_eig
+    }
+    df = extract_features(
+        data, sfreq, [selected_func], func_params, ch_names=ch_names,
+        return_as_df=True)
+    expected_col_names = [
+        (selected_func, ch_names[i] + '-' + ch_names[j])
+        for s, i, j in _idxiter(n_channels, include_diag=include_diag)]
+    if with_eig:
+        expected_col_names.extend(
+            [(selected_func, f'eig{i}') for i in range(n_channels)])
+
+    assert df.columns.values.tolist() == expected_col_names
 
 
 if __name__ == '__main__':
@@ -185,3 +247,5 @@ if __name__ == '__main__':
     test_memory_feature_extractor()
     test_user_defined_feature_function()
     test_channel_naming()
+    test_channel_naming_pow_freq_bands()
+    test_channel_naming_bivariate()


### PR DESCRIPTION
This should be the last PR for today. :)

This PR (1) extends feature naming with channel name replacement to bivariate functions as for univariate functions, and (2) fixes channel name replacement when we have overlapping channel names (e.g., Cz and FCz).