### PR TITLE
Optimizing regexp execution

### DIFF
--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -224,9 +224,9 @@ def _apply_extractor(extractor, X, ch_names, return_as_df):
             mapping = {'ch%s' % i: ch_name
                        for i, ch_name in enumerate(ch_names)}
             for pattern, translation in mapping.items():
+                r = re.compile(rf'{pattern}(?=_)|{pattern}\b')
                 feature_names = [
-                    re.sub(pattern=rf'{pattern}(?=_)|{pattern}\b',
-                           string=feature_name, repl=translation)
+                    r.sub(string=feature_name, repl=translation)
                     for feature_name in feature_names]
 
     return X, feature_names


### PR DESCRIPTION
I noticed the regexps introduced in my last PR (#63) to find channel names in feature strings were pretty slow. In this commit the regexp are compiled once per combination instead. In a quick test with 21 channels and about 2000 features, the overall time taken by the `re` module went from 14 s to ~3.5 s.