### PR TITLE
Fixing quantile features order

### DIFF
--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -113,7 +113,7 @@ def test_quantile():
     expected = np.array([0., 1.])
     assert_almost_equal(compute_quantile(data1, q=0.75), expected)
     # Multiple quantiles
-    expected = np.array([-1, -0.25, 0., 1.])
+    expected = np.array([-1, 0, -0.25, 1.])
     assert_almost_equal(compute_quantile(data1, q=[0.25, 0.75]), expected)
 
 

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -295,7 +295,7 @@ def compute_quantile(data, q=0.75):
     -----
     Alias of the feature function: *quantile*
     """
-    return np.ravel(np.quantile(data, q, axis=-1))
+    return np.ravel(np.quantile(data, q, axis=-1), order='F')
 
 
 def _compute_quantile_feat_names(data, q, **kwargs):


### PR DESCRIPTION
I made a mistake in #61 - the order of quantile features was [ch1_q1, ch2_q1, ch1_q2, ch2_q2] instead of [ch1_q1, ch1_q2, ch2_q1, ch2_q2] as for the other features that have more than one value per channel. This PR fixes the function and its test.