### PR TITLE
[FIX] Passing reset=True in FeatureFunctionTransformer._check_input()

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,7 @@ Bug
 
 - Fixed the behavior of the `edge` parameter in :func:`mne_features.univariate.compute_spect_edge_freq`. Valid values for this parameter are now `None` or a list of float between `0` and `1` (percentages). By `Jean-Baptiste SCHIRATTI`_ in `#52 <https://github.com/mne-tools/mne-features/pull/52>`_.
 - Fixed channel name replacement with overlapping channel names (e.g., Cz and FCz) which affected :func:`mne_features.extract_features` with `return_as_df=True` and when `ch_names` are provided. By `Hubert Banville`_ in `#63 <https://github.com/mne-tools/mne-features/pull/63>`_.
+- Fixed :class:`feature_extraction.FeatureFunctionTransformer`'s `check_input` method following sickit-learn 1.0 release: passing `reset=True`. By `Paul ROUJANSKY`_ in `#70 <https://github.com/mne-tools/mne-features/pull/70>`_.
 
 API
 ~~~

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -100,7 +100,7 @@ class FeatureFunctionTransformer(FunctionTransformer):
         -------
         self
         """
-        self._check_input(X)
+        self._check_input(X, reset=True)
         _feature_func = _get_python_func(self.func)
         if hasattr(_feature_func, 'get_feature_names'):
             _params = self.get_params()


### PR DESCRIPTION
Fixing https://github.com/mne-tools/mne-features/issues/69