### PR TITLE
MAINT: Explicit nopython

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         python-version: [ "3.8" ]
         numba: [ "on", "off" ]
+    continue-on-error: true
     name: python-${{ matrix.python-version }}-numba-${{ matrix.numba }}
     steps:
     - uses: actions/checkout@v2

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -134,7 +134,7 @@ def test_memory_feature_extractor():
 
 def test_user_defined_feature_function():
     # User-defined feature function
-    @nb.jit()
+    @nb.jit(nopython=True)
     def top_feature(arr, gamma=3.14):
         return np.sum(np.power(gamma * arr, 3) - np.power(arr / gamma, 2),
                       axis=-1)

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -449,7 +449,7 @@ def _app_samp_entropy_helper(data, emb, metric='chebyshev',
     _all_metrics = KDTree.valid_metrics
     try:  # new sklearn this is a method not a list
         _all_metrics = KDTree.valid_metrics()
-    except TypeError:
+    except TypeError:  # pragma: no-cover
         pass
     if metric not in _all_metrics:
         raise ValueError('The given metric (%s) is not valid. The valid '

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -447,6 +447,10 @@ def _app_samp_entropy_helper(data, emb, metric='chebyshev',
     output : ndarray, shape (n_channels, 2)
     """
     _all_metrics = KDTree.valid_metrics
+    try:  # new sklearn this is a method not a list
+        _all_metrics = KDTree.valid_metrics()
+    except TypeError:
+        pass
     if metric not in _all_metrics:
         raise ValueError('The given metric (%s) is not valid. The valid '
                          'metric names are: %s' % (metric, _all_metrics))

--- a/mne_features/utils.py
+++ b/mne_features/utils.py
@@ -18,7 +18,7 @@ from mne.time_frequency import psd_array_welch, psd_array_multitaper
 from .mock_numba import nb
 
 
-@nb.jit()
+@nb.jit(nopython=True)
 def _idxiter(n, triu=True, include_diag=False):
     """Enumeration of the upper-triangular part of a squre matrix.
 


### PR DESCRIPTION
In `mne.sys_info` we get warnings when importing `mne_features`:
```
/Library/mne-python/lib/python3.11/site-packages/mne_features/utils.py:21: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
```
This just tries setting all to `nopython=True`. Maybe some need to be `nopython=False`, hopefully some CI will tell us if that's the case...