### PR TITLE
Forward feature names in FeaturesExtractor

### DIFF
--- a/examples/plot_feature_names_analysis.py
+++ b/examples/plot_feature_names_analysis.py
@@ -108,3 +108,14 @@ print(
     + f"{100*np.sum(pipe.named_steps['clf'].feature_importances_[best_10_id]):.2f}% "
     + "of the prediction."
 )
+
+###############################################################################
+# Print the channel with most contribution.
+
+feat_as_ch = np.array(
+    [f.split("__")[0] for f in pipe.named_steps["clf"].feature_names_in_])
+ch_names = epochs.info["ch_names"]
+d = {ch: np.sum(
+    pipe.named_steps["clf"].feature_importances_[feat_as_ch == ch]) for ch in ch_names}
+best_ch = max(d, key=d.get)
+print(f"Channel {best_ch} contributes the most with {100*d[best_ch]:.2f}%.")

--- a/examples/plot_feature_names_analysis.py
+++ b/examples/plot_feature_names_analysis.py
@@ -80,10 +80,9 @@ pipe = Pipeline(
             FeatureExtractor(
                 sfreq=raw.info["sfreq"],
                 ch_names=epochs.info["ch_names"],
-                return_as_df=True,
                 selected_funcs=selected_funcs,
                 params=params,
-            ),
+            ).set_output(transform="pandas"),
         ),
         ("scaler", StandardScaler().set_output(transform="pandas")),
         ("clf", ExtraTreesClassifier(random_state=42)),

--- a/examples/plot_feature_names_analysis.py
+++ b/examples/plot_feature_names_analysis.py
@@ -1,0 +1,111 @@
+"""
+================================
+Analyze the feature importances.
+================================
+
+The example shows how feature names are forwarded in sklearn pipelines
+so that one can have easy access to them for analysis purpose.
+
+The code for this example is based on the method proposed in:
+
+Jean-Baptiste SCHIRATTI, Jean-Eudes LE DOUGET, Michel LE VAN QUYEN,
+Slim ESSID, Alexandre GRAMFORT,
+"An ensemble learning approach to detect epileptic seizures from long
+intracranial EEG recordings"
+Proc. IEEE ICASSP Conf. 2018
+
+.. note::
+
+    This example is for illustration purposes, as other methods
+    may lead to better performance on such a dataset (classification
+    of auditory vs. visual stimuli).
+
+"""
+# Author: Jean-Baptiste Schiratti <jean.baptiste.schiratti@gmail.com>
+#         Alexandre Gramfort <alexandre.gramfort@inria.fr>
+#         Etienne de Montalivet <etienne.demontalivet@protonmail.com>
+# License: BSD 3 clause
+
+import numpy as np
+import mne
+from mne.datasets import sample
+
+from sklearn.ensemble import ExtraTreesClassifier
+from sklearn.model_selection import train_test_split, StratifiedKFold
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from mne_features.feature_extraction import FeatureExtractor
+
+print(__doc__)
+###############################################################################
+# Let us import the data using MNE-Python and epoch it:
+
+data_path = sample.data_path()
+raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+tmin, tmax = -0.2, 0.5
+event_id = dict(aud_l=1, vis_l=3)
+
+# Setup for reading the raw data
+raw = mne.io.read_raw_fif(raw_fname, preload=True)
+raw.filter(.5, None, fir_design='firwin')
+events = mne.read_events(event_fname)
+picks = mne.pick_types(raw.info, meg=False, eeg=True)
+
+# Read epochs
+epochs = mne.Epochs(raw, events, event_id, tmin, tmax, picks=picks, proj=True,
+                    baseline=None, preload=True)
+labels = epochs.events[:, -1]
+
+# get MEG and EEG data
+data = epochs.get_data()
+
+###############################################################################
+# Prepare for the classification task
+# -----------------------------------
+#
+# In addition to the new feature function, we also propose to extract the
+# mean of the data:
+selected_funcs = ["pow_freq_bands"]
+params = {
+    "pow_freq_bands__freq_bands": [0.5, 4, 8, 12, 30, 50, 70],
+    "pow_freq_bands__log": True,
+}
+
+pipe = Pipeline(
+    [
+        (
+            "fe",
+            FeatureExtractor(
+                sfreq=raw.info["sfreq"],
+                ch_names=epochs.info["ch_names"],
+                return_as_df=True,
+                selected_funcs=selected_funcs,
+                params=params,
+            ),
+        ),
+        ("scaler", StandardScaler().set_output(transform="pandas")),
+        ("clf", ExtraTreesClassifier(random_state=42)),
+    ]
+)
+skf = StratifiedKFold(n_splits=3, shuffle=True, random_state=42)
+y = labels
+
+###############################################################################
+# Print the accuracy score on a test dataset.
+
+X_train, X_test, y_train, y_test = train_test_split(data, y, test_size=0.2)
+accuracy = pipe.fit(X_train, y_train).score(X_test, y_test)
+print("Accuracy score = %1.3f" % accuracy)
+
+###############################################################################
+# Print the 10 most important features and their contribution.
+
+best_10_id = np.argsort(pipe.named_steps["clf"].feature_importances_)[-10:][::-1]
+best_10 = pipe.named_steps["clf"].feature_names_in_[best_10_id]
+print(
+    f"These 10 features ({best_10}) are responsible for "
+    + f"{100*np.sum(pipe.named_steps['clf'].feature_importances_[best_10_id]):.2f}% "
+    + "of the prediction."
+)

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -328,12 +328,12 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
         intersect the aliases used by mne-features. If the name given to a
         user-defined feature function is already used as an alias in
         mne-features, an error will be raised.
-        
+
     ch_names : list of str or None (default: None)
         Channel names. Only used if ``return_as_df`` is True. If not None,
         channel names will be used to rename the columns of the output
         with the following format: ``[ch_name]__[feature_name]``.
-        
+
     return_as_df : bool (default: False)
         If True, the extracted features will be returned as a Pandas DataFrame.
 
@@ -369,7 +369,7 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, sfreq=256., ch_names=None, return_as_df=False,
-                 selected_funcs=None, params=None, n_jobs=1,memory=None):
+                 selected_funcs=None, params=None, n_jobs=1, memory=None):
         """Instantiate a FeatureExtractor object."""
         self.sfreq = sfreq
         self.ch_names = ch_names
@@ -392,8 +392,9 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
             ch_names=self.ch_names,
             return_as_df=True,
         )
+        cols = df.columns
         self.feature_names = [
-            f"{df.columns[i][1]}__{df.columns[i][0]}" for i in range(df.shape[1])
+            f"{cols[i][1]}__{cols[i][0]}" for i in range(df.shape[1])
         ]
         return self
 

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -194,7 +194,7 @@ def _format_as_dataframe(X, feature_names):
                          '`X.shape[1]` (`n_features`).')
     else:
         _names = [n.split('__')[0] for n in feature_names]
-        _idx = [n.split('__')[1] for n in feature_names]
+        _idx = [n[len(n.split('__')[0])+2:] for n in feature_names]
         columns = pd.MultiIndex.from_arrays([_names, _idx])
         return pd.DataFrame(data=X, columns=columns)
 

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -330,15 +330,15 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
         user-defined feature function is already used as an alias in
         mne-features, an error will be raised.
 
-    ch_names : list of str or None (default: None)
-        Channel names. Only used to get proper channels in ``feature_names``.
-        If None, channel names will be of the form ``ch0``, ``ch1``, etc.
-
     params : dict or None (default: None)
         If not None, dict of optional parameters to be passed to
         :func:`extract_features`. Each key of the ``funcs_params`` dict should
         be of the form: ``[alias_feature_function]__[optional_param]``
         (for example: ``higuchi_fd__kmax``).
+
+    ch_names : list of str or None (default: None)
+        Channel names. Only used to get proper channels in ``feature_names``.
+        If None, channel names will be of the form ``ch0``, ``ch1``, etc.
 
     n_jobs : int (default: 1)
         Number of CPU cores used when parallelizing the feature extraction.
@@ -365,16 +365,18 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
     :func:`extract_features`
     """
 
-    def __init__(self, sfreq=256., ch_names=None, selected_funcs=None,
-                 params=None, n_jobs=1, memory=None):
+    def __init__(self, sfreq=256., selected_funcs=None, params=None,
+                 ch_names=None, n_jobs=1, memory=None):
         """Instantiate a FeatureExtractor object."""
         self.sfreq = sfreq
         self.ch_names = ch_names
         self.feature_names = None
         self.selected_funcs = selected_funcs
         self.params = params
+        self.ch_names = ch_names
         self.n_jobs = n_jobs
         self.memory = memory
+        self.feature_names = None
 
     def fit(self, X, y=None):
         """Get the feature names"""

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -299,8 +299,8 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
 
     The method ``fit_transform`` implemented in this class can be used to
     extract univariate or bivariate features from epoched data
-    (see example below). The method ``fit`` is implemented for compatibility 
-    with Scikit-learn's API and extract the feature names with format 
+    (see example below). The method ``fit`` is implemented for compatibility
+    with Scikit-learn's API and extracts the feature names with format
     ``<ch_name>__<func_params>__<feature>``. As a result, the class
     ``FeatureExtractor`` can be used as a step in a Pipeline (see
     :class:`~sklearn.pipeline.Pipeline` and MNE-features examples). The class

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -299,9 +299,10 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
 
     The method ``fit_transform`` implemented in this class can be used to
     extract univariate or bivariate features from epoched data
-    (see example below). The method ``fit`` does not have any effect and is
-    implemented for compatibility with Scikit-learn's API. As a result, the
-    class ``FeatureExtractor`` can be used as a step in a Pipeline (see
+    (see example below). The method ``fit`` is implemented for compatibility 
+    with Scikit-learn's API and extract the feature names with format 
+    ``<ch_name>__<func_params>__<feature>``. As a result, the class
+    ``FeatureExtractor`` can be used as a step in a Pipeline (see
     :class:`~sklearn.pipeline.Pipeline` and MNE-features examples). The class
     also accepts a ``memory`` parameter which allows for caching the result of
     feature extraction. Therefore, if caching is used, calling
@@ -330,9 +331,8 @@ class FeatureExtractor(BaseEstimator, TransformerMixin):
         mne-features, an error will be raised.
 
     ch_names : list of str or None (default: None)
-        Channel names. Only used to get proper ``feature_names``. If not None,
-        channel names will be used to rename the feature names with the
-        following format: ``<ch_name>__<feature_name>``.
+        Channel names. Only used to get proper channels in ``feature_names``.
+        If None, channel names will be of the form ``ch0``, ``ch1``, etc.
 
     params : dict or None (default: None)
         If not None, dict of optional parameters to be passed to

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -159,37 +159,42 @@ def test_user_defined_feature_function():
 
 def test_channel_naming():
     ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
-    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP_1']
     selected_funcs = ['app_entropy']
     df = extract_features(
-        data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True)
+        data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True,
+        )
     expected_col_names = [('app_entropy', ch_name) for ch_name in ch_names]
     assert df.columns.values.tolist() == expected_col_names
 
     fe = FeatureExtractor(
-        sfreq, ch_names=ch_names, selected_funcs=selected_funcs
+        sfreq, ch_names=ch_names, selected_funcs=selected_funcs,
     ).set_output(transform="pandas")
     df = fe.fit_transform(data)
-    expected_col_names = [f"{ch_name}__app_entropy" for ch_name in ch_names]
+    expected_col_names = [f"{ch_name}__app_entropy"
+                          for ch_name in ch_names]
     assert df.columns.values.tolist() == expected_col_names
 
     fe = FeatureExtractor(
         sfreq, selected_funcs=selected_funcs
     ).set_output(transform="pandas")
     df = fe.fit_transform(data)
-    expected_col_names = [f"ch{i}__app_entropy" for i in range(n_channels)]
+    expected_col_names = [f"ch{i}__app_entropy"
+                          for i in range(n_channels)]
     assert df.columns.values.tolist() == expected_col_names
 
-    ch_names.append('CHANNEL%s' % n_channels)
+    ch_names[0] = "µ&mne-features&µ_whatever"
     with assert_raises(ValueError):
-        # incorrect number of channel names
-        df = extract_features(
-            data, sfreq, selected_funcs, ch_names=ch_names, return_as_df=True)
+        # incorrect channel name
+        fe = FeatureExtractor(
+            sfreq, selected_funcs=selected_funcs, ch_names=ch_names
+        ).set_output(transform="pandas")
+        df = fe.fit_transform(data)
 
 
 def test_channel_naming_pow_freq_bands():
     ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
-    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP_1']
     selected_funcs = ['pow_freq_bands']
     func_params = {
         'pow_freq_bands__freq_bands': np.array([[0, 2], [10, 20]]),
@@ -200,12 +205,12 @@ def test_channel_naming_pow_freq_bands():
         return_as_df=True)
 
     expected_col_names = [
-        ('pow_freq_bands', f'{ch_name}__band{i}/band{j}')
+        ('pow_freq_bands', f'{ch_name}_band{i}/band{j}')
         for ch_name in ch_names for _, i, j in _idxiter(2, triu=False)]
     assert df.columns.values.tolist() == expected_col_names
 
     fe = FeatureExtractor(
-        sfreq, ch_names, selected_funcs, func_params
+        sfreq, selected_funcs, func_params, ch_names
     ).set_output(transform="pandas")
     df = fe.fit_transform(data)
     expected_col_names = [
@@ -219,7 +224,7 @@ def test_channel_naming_pow_freq_bands():
 @pytest.mark.parametrize('include_diag', [True, False])
 def test_channel_naming_bivariate(selected_func, include_diag):
     ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
-    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP_1']
     func_params = {selected_func + '__include_diag': include_diag}
     df = extract_features(
         data, sfreq, [selected_func], func_params, ch_names=ch_names,
@@ -231,7 +236,7 @@ def test_channel_naming_bivariate(selected_func, include_diag):
     assert df.columns.values.tolist() == expected_col_names
 
     fe = FeatureExtractor(
-        sfreq, ch_names, [selected_func], func_params
+        sfreq, [selected_func], func_params, ch_names
     ).set_output(transform="pandas")
     df = fe.fit_transform(data)
     expected_col_names = [
@@ -245,7 +250,7 @@ def test_channel_naming_bivariate(selected_func, include_diag):
 @pytest.mark.parametrize('with_eig', [True, False])
 def test_channel_naming_bivariate_eig(selected_func, include_diag, with_eig):
     ch_names = ['CHANNEL%s' % i for i in range(n_channels)]
-    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP1']
+    ch_names[:4] = ['Cz', 'FCz', 'P1', 'CP_1']
     func_params = {
         selected_func + '__include_diag': include_diag,
         selected_func + '__with_eigenvalues': with_eig
@@ -263,7 +268,7 @@ def test_channel_naming_bivariate_eig(selected_func, include_diag, with_eig):
     assert df.columns.values.tolist() == expected_col_names
 
     fe = FeatureExtractor(
-        sfreq, ch_names, [selected_func], func_params
+        sfreq, [selected_func], func_params, ch_names
     ).set_output(transform="pandas")
     df = fe.fit_transform(data)
     expected_col_names = [

--- a/mne_features/tests/test_feature_extraction.py
+++ b/mne_features/tests/test_feature_extraction.py
@@ -186,7 +186,7 @@ def test_channel_naming_pow_freq_bands():
         return_as_df=True)
 
     expected_col_names = [
-        ('pow_freq_bands', f'{ch_name}_band{i}/band{j}')
+        ('pow_freq_bands', f'{ch_name}__band{i}/band{j}')
         for ch_name in ch_names for _, i, j in _idxiter(2, triu=False)]
     assert df.columns.values.tolist() == expected_col_names
 

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -301,7 +301,7 @@ def test_feature_names_quantile():
     selected_funcs = ['quantile']
 
     q = [0.25, 0.75]
-    col_names = ['ch%s__%s' % (ch, i) for ch in range(n_chans)
+    col_names = ['ch%s_%s' % (ch, i) for ch in range(n_chans)
                  for i in range(len(q))]
     df = extract_features(
         _data, sfreq, selected_funcs, funcs_params={'quantile__q': q},
@@ -319,7 +319,7 @@ def test_feature_names_spect_edge_freq():
     for edge in _edges:
         if edge is None:
             edge = [.5]
-        col_names = ['ch%s__%s' % (ch, i) for ch in range(n_chans) for
+        col_names = ['ch%s_%s' % (ch, i) for ch in range(n_chans) for
                      i in range(len(edge))]
         df = extract_features(
             _data, sfreq, selected_funcs,
@@ -335,7 +335,7 @@ def test_feature_names_spect_slope():
 
     stats = ['intercept', 'slope', 'MSE', 'R2']
 
-    col_names = ['ch%s__%s' % (ch, stat) for ch in range(n_chans) for
+    col_names = ['ch%s_%s' % (ch, stat) for ch in range(n_chans) for
                  stat in stats]
     df = extract_features(_data, sfreq, selected_funcs, return_as_df=True)
     assert_equal(df.columns.get_level_values(1).values, col_names)
@@ -350,7 +350,7 @@ def test_feature_names_wavelet_coef_energy(wavelet_name='db4'):
     wavelet = pywt.Wavelet(wavelet_name)
     levdec = min(pywt.dwt_max_level(_data.shape[-1], wavelet.dec_len), 6)
 
-    col_names = ['ch%s__%s' % (ch, i) for ch in range(n_chans) for
+    col_names = ['ch%s_%s' % (ch, i) for ch in range(n_chans) for
                  i in range(levdec)]
 
     df = extract_features(
@@ -369,7 +369,7 @@ def test_feature_names_teager_kaiser_energy(wavelet_name='db4'):
     wavelet = pywt.Wavelet(wavelet_name)
     levdec = min(pywt.dwt_max_level(_data.shape[-1], wavelet.dec_len), 6)
 
-    col_names = ['ch%s__%s_%s' % (ch, i, stat) for ch in range(n_chans)
+    col_names = ['ch%s_%s_%s' % (ch, i, stat) for ch in range(n_chans)
                  for i in range(levdec + 1) for stat in ['mean', 'std']]
 
     df = extract_features(
@@ -385,14 +385,14 @@ def test_feature_names_pow_freq_bands():
     fb1 = np.array([[4., 8.], [30., 70.]])
     fb2 = {'theta': [4, 8], 'low-gamma': np.array([30, 70])}
     _fb = [fb1, fb2]
-    ratios_col_names1 = ['ch0__band0/band1', 'ch0__band1/band0',
-                         'ch1__band0/band1', 'ch1__band1/band0']
-    ratios_col_names2 = ['ch0__theta/low-gamma', 'ch0__low-gamma/theta',
-                         'ch1__theta/low-gamma', 'ch1__low-gamma/theta']
+    ratios_col_names1 = ['ch0_band0/band1', 'ch0_band1/band0',
+                         'ch1_band0/band1', 'ch1_band1/band0']
+    ratios_col_names2 = ['ch0_theta/low-gamma', 'ch0_low-gamma/theta',
+                         'ch1_theta/low-gamma', 'ch1_low-gamma/theta']
     _ratios_names = [ratios_col_names1, ratios_col_names2]
-    pow_col_names1 = ['ch0__band0', 'ch0__band1', 'ch1__band0', 'ch1__band1']
-    pow_col_names2 = ['ch0__theta', 'ch0__low-gamma',
-                      'ch1__theta', 'ch1__low-gamma']
+    pow_col_names1 = ['ch0_band0', 'ch0_band1', 'ch1_band0', 'ch1_band1']
+    pow_col_names2 = ['ch0_theta', 'ch0_low-gamma',
+                      'ch1_theta', 'ch1_low-gamma']
     _pow_names = [pow_col_names1, pow_col_names2]
 
     for fb, ratios_names, pow_names in zip(_fb, _ratios_names, _pow_names):
@@ -521,9 +521,9 @@ def test_feature_names_energy_freq_bands():
     fb1 = np.array([[4., 8.], [30., 70.]])
     fb2 = {'theta': [4, 8], 'low-gamma': np.array([30, 70])}
     _fb = [fb1, fb2]
-    expected_names1 = ['ch0__band0', 'ch0__band1', 'ch1__band0', 'ch1__band1']
-    expected_names2 = ['ch0__theta', 'ch0__low-gamma',
-                       'ch1__theta', 'ch1__low-gamma']
+    expected_names1 = ['ch0_band0', 'ch0_band1', 'ch1_band0', 'ch1_band1']
+    expected_names2 = ['ch0_theta', 'ch0_low-gamma',
+                       'ch1_theta', 'ch1_low-gamma']
     _expected_names = [expected_names1, expected_names2]
 
     for fb, feat_names in zip(_fb, _expected_names):

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -301,7 +301,7 @@ def test_feature_names_quantile():
     selected_funcs = ['quantile']
 
     q = [0.25, 0.75]
-    col_names = ['ch%s_%s' % (ch, i) for ch in range(n_chans)
+    col_names = ['ch%s__%s' % (ch, i) for ch in range(n_chans)
                  for i in range(len(q))]
     df = extract_features(
         _data, sfreq, selected_funcs, funcs_params={'quantile__q': q},
@@ -319,7 +319,7 @@ def test_feature_names_spect_edge_freq():
     for edge in _edges:
         if edge is None:
             edge = [.5]
-        col_names = ['ch%s_%s' % (ch, i) for ch in range(n_chans) for
+        col_names = ['ch%s__%s' % (ch, i) for ch in range(n_chans) for
                      i in range(len(edge))]
         df = extract_features(
             _data, sfreq, selected_funcs,
@@ -335,7 +335,7 @@ def test_feature_names_spect_slope():
 
     stats = ['intercept', 'slope', 'MSE', 'R2']
 
-    col_names = ['ch%s_%s' % (ch, stat) for ch in range(n_chans) for
+    col_names = ['ch%s__%s' % (ch, stat) for ch in range(n_chans) for
                  stat in stats]
     df = extract_features(_data, sfreq, selected_funcs, return_as_df=True)
     assert_equal(df.columns.get_level_values(1).values, col_names)
@@ -350,7 +350,7 @@ def test_feature_names_wavelet_coef_energy(wavelet_name='db4'):
     wavelet = pywt.Wavelet(wavelet_name)
     levdec = min(pywt.dwt_max_level(_data.shape[-1], wavelet.dec_len), 6)
 
-    col_names = ['ch%s_%s' % (ch, i) for ch in range(n_chans) for
+    col_names = ['ch%s__%s' % (ch, i) for ch in range(n_chans) for
                  i in range(levdec)]
 
     df = extract_features(
@@ -369,7 +369,7 @@ def test_feature_names_teager_kaiser_energy(wavelet_name='db4'):
     wavelet = pywt.Wavelet(wavelet_name)
     levdec = min(pywt.dwt_max_level(_data.shape[-1], wavelet.dec_len), 6)
 
-    col_names = ['ch%s_%s_%s' % (ch, i, stat) for ch in range(n_chans)
+    col_names = ['ch%s__%s_%s' % (ch, i, stat) for ch in range(n_chans)
                  for i in range(levdec + 1) for stat in ['mean', 'std']]
 
     df = extract_features(
@@ -385,14 +385,14 @@ def test_feature_names_pow_freq_bands():
     fb1 = np.array([[4., 8.], [30., 70.]])
     fb2 = {'theta': [4, 8], 'low-gamma': np.array([30, 70])}
     _fb = [fb1, fb2]
-    ratios_col_names1 = ['ch0_band0/band1', 'ch0_band1/band0',
-                         'ch1_band0/band1', 'ch1_band1/band0']
-    ratios_col_names2 = ['ch0_theta/low-gamma', 'ch0_low-gamma/theta',
-                         'ch1_theta/low-gamma', 'ch1_low-gamma/theta']
+    ratios_col_names1 = ['ch0__band0/band1', 'ch0__band1/band0',
+                         'ch1__band0/band1', 'ch1__band1/band0']
+    ratios_col_names2 = ['ch0__theta/low-gamma', 'ch0__low-gamma/theta',
+                         'ch1__theta/low-gamma', 'ch1__low-gamma/theta']
     _ratios_names = [ratios_col_names1, ratios_col_names2]
-    pow_col_names1 = ['ch0_band0', 'ch0_band1', 'ch1_band0', 'ch1_band1']
-    pow_col_names2 = ['ch0_theta', 'ch0_low-gamma',
-                      'ch1_theta', 'ch1_low-gamma']
+    pow_col_names1 = ['ch0__band0', 'ch0__band1', 'ch1__band0', 'ch1__band1']
+    pow_col_names2 = ['ch0__theta', 'ch0__low-gamma',
+                      'ch1__theta', 'ch1__low-gamma']
     _pow_names = [pow_col_names1, pow_col_names2]
 
     for fb, ratios_names, pow_names in zip(_fb, _ratios_names, _pow_names):
@@ -521,9 +521,9 @@ def test_feature_names_energy_freq_bands():
     fb1 = np.array([[4., 8.], [30., 70.]])
     fb2 = {'theta': [4, 8], 'low-gamma': np.array([30, 70])}
     _fb = [fb1, fb2]
-    expected_names1 = ['ch0_band0', 'ch0_band1', 'ch1_band0', 'ch1_band1']
-    expected_names2 = ['ch0_theta', 'ch0_low-gamma',
-                       'ch1_theta', 'ch1_low-gamma']
+    expected_names1 = ['ch0__band0', 'ch0__band1', 'ch1__band0', 'ch1__band1']
+    expected_names2 = ['ch0__theta', 'ch0__low-gamma',
+                       'ch1__theta', 'ch1__low-gamma']
     _expected_names = [expected_names1, expected_names2]
 
     for fb, feat_names in zip(_fb, _expected_names):

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -307,7 +307,7 @@ def _compute_quantile_feat_names(data, q, **kwargs):
     if n_quantiles == 1:
         return ['ch%s' % ch for ch in range(n_channels)]
     else:
-        return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
+        return ['ch%s__%s' % (ch, i) for ch in range(n_channels)
                 for i in range(n_quantiles)]
 
 
@@ -766,10 +766,10 @@ def _compute_pow_freq_bands_feat_names(data, freq_bands, normalize, ratios,
         n_freq_bands = (freq_bands.shape[0] - 1 if freq_bands.ndim == 1
                         else freq_bands.shape[0])
         _band_names = ['band' + str(j) for j in range(n_freq_bands)]
-    ratios_names = ['ch%s_%s/%s' % (ch, _band_names[i], _band_names[j])
+    ratios_names = ['ch%s__%s/%s' % (ch, _band_names[i], _band_names[j])
                     for ch in range(n_channels) for _, i, j in
                     _idxiter(n_freq_bands, triu=ratios_triu)]
-    pow_names = ['ch%s_%s' % (ch, _band_names[i]) for ch in
+    pow_names = ['ch%s__%s' % (ch, _band_names[i]) for ch in
                  range(n_channels) for i in range(n_freq_bands)]
     if ratios is None:
         return pow_names
@@ -1286,7 +1286,7 @@ def _compute_spect_slope_feat_names(data, **kwargs):
     :func:`mne_features.univariate.compute_energy_freq_bands`."""
     n_channels = data.shape[0]
     stats = ['intercept', 'slope', 'MSE', 'R2']
-    return ['ch%s_%s' % (ch, stat) for ch in range(n_channels)
+    return ['ch%s__%s' % (ch, stat) for ch in range(n_channels)
             for stat in stats]
 
 
@@ -1402,7 +1402,7 @@ def _compute_energy_fb_feat_names(data, freq_bands, deriv_filt):
         n_freq_bands = (freq_bands.shape[0] - 1 if freq_bands.ndim == 1
                         else freq_bands.shape[0])
         _band_names = ['band' + str(j) for j in range(n_freq_bands)]
-    return ['ch%s_%s' % (ch, _band_names[i]) for ch in range(n_channels)
+    return ['ch%s__%s' % (ch, _band_names[i]) for ch in range(n_channels)
             for i in range(n_freq_bands)]
 
 
@@ -1498,7 +1498,7 @@ def _compute_spect_edge_freq_feat_names(data, edge, **kwargs):
         else:
             _edge = edge
     n_edges = len(_edge)
-    return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
+    return ['ch%s__%s' % (ch, i) for ch in range(n_channels)
             for i in range(n_edges)]
 
 
@@ -1550,7 +1550,7 @@ def _compute_wavelet_coef_energy_feat_names(data, wavelet_name, **kwargs):
     n_channels = data.shape[0]
     coefs = _wavelet_coefs(data, wavelet_name)
     levdec = len(coefs) - 1
-    return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
+    return ['ch%s__%s' % (ch, i) for ch in range(n_channels)
             for i in range(levdec)]
 
 
@@ -1624,7 +1624,7 @@ def _compute_teager_kaiser_energy_feat_names(data, wavelet_name, **kwargs):
     n_channels = data.shape[0]
     coefs = _wavelet_coefs(data, wavelet_name)
     levdec = len(coefs) - 1
-    return ['ch%s_%s_%s' % (ch, i, stat) for ch in range(n_channels)
+    return ['ch%s__%s_%s' % (ch, i, stat) for ch in range(n_channels)
             for i in range(levdec + 1) for stat in ['mean', 'std']]
 
 

--- a/mne_features/univariate.py
+++ b/mne_features/univariate.py
@@ -307,7 +307,7 @@ def _compute_quantile_feat_names(data, q, **kwargs):
     if n_quantiles == 1:
         return ['ch%s' % ch for ch in range(n_channels)]
     else:
-        return ['ch%s__%s' % (ch, i) for ch in range(n_channels)
+        return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
                 for i in range(n_quantiles)]
 
 
@@ -766,10 +766,10 @@ def _compute_pow_freq_bands_feat_names(data, freq_bands, normalize, ratios,
         n_freq_bands = (freq_bands.shape[0] - 1 if freq_bands.ndim == 1
                         else freq_bands.shape[0])
         _band_names = ['band' + str(j) for j in range(n_freq_bands)]
-    ratios_names = ['ch%s__%s/%s' % (ch, _band_names[i], _band_names[j])
+    ratios_names = ['ch%s_%s/%s' % (ch, _band_names[i], _band_names[j])
                     for ch in range(n_channels) for _, i, j in
                     _idxiter(n_freq_bands, triu=ratios_triu)]
-    pow_names = ['ch%s__%s' % (ch, _band_names[i]) for ch in
+    pow_names = ['ch%s_%s' % (ch, _band_names[i]) for ch in
                  range(n_channels) for i in range(n_freq_bands)]
     if ratios is None:
         return pow_names
@@ -1286,7 +1286,7 @@ def _compute_spect_slope_feat_names(data, **kwargs):
     :func:`mne_features.univariate.compute_energy_freq_bands`."""
     n_channels = data.shape[0]
     stats = ['intercept', 'slope', 'MSE', 'R2']
-    return ['ch%s__%s' % (ch, stat) for ch in range(n_channels)
+    return ['ch%s_%s' % (ch, stat) for ch in range(n_channels)
             for stat in stats]
 
 
@@ -1402,7 +1402,7 @@ def _compute_energy_fb_feat_names(data, freq_bands, deriv_filt):
         n_freq_bands = (freq_bands.shape[0] - 1 if freq_bands.ndim == 1
                         else freq_bands.shape[0])
         _band_names = ['band' + str(j) for j in range(n_freq_bands)]
-    return ['ch%s__%s' % (ch, _band_names[i]) for ch in range(n_channels)
+    return ['ch%s_%s' % (ch, _band_names[i]) for ch in range(n_channels)
             for i in range(n_freq_bands)]
 
 
@@ -1498,7 +1498,7 @@ def _compute_spect_edge_freq_feat_names(data, edge, **kwargs):
         else:
             _edge = edge
     n_edges = len(_edge)
-    return ['ch%s__%s' % (ch, i) for ch in range(n_channels)
+    return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
             for i in range(n_edges)]
 
 
@@ -1550,7 +1550,7 @@ def _compute_wavelet_coef_energy_feat_names(data, wavelet_name, **kwargs):
     n_channels = data.shape[0]
     coefs = _wavelet_coefs(data, wavelet_name)
     levdec = len(coefs) - 1
-    return ['ch%s__%s' % (ch, i) for ch in range(n_channels)
+    return ['ch%s_%s' % (ch, i) for ch in range(n_channels)
             for i in range(levdec)]
 
 
@@ -1624,7 +1624,7 @@ def _compute_teager_kaiser_energy_feat_names(data, wavelet_name, **kwargs):
     n_channels = data.shape[0]
     coefs = _wavelet_coefs(data, wavelet_name)
     levdec = len(coefs) - 1
-    return ['ch%s__%s_%s' % (ch, i, stat) for ch in range(n_channels)
+    return ['ch%s_%s_%s' % (ch, i, stat) for ch in range(n_channels)
             for i in range(levdec + 1) for stat in ['mean', 'std']]
 
 


### PR DESCRIPTION
It would be convenient to have the feature names also in `FeaturesExtractor` (and not only with `extract_features`).
Typical use would be in sklearn pipelines (that now support this feature names forwarding very well).

My implementation is probably not the best (using `extract_features` during `fit` on the first epoch of data to get the feature names...) but I tried it with a simple example and it works well.

What do you think of including `feature_names` mechanism into `FeaturesExtractor` ?
The current implementation ? Please tell me how I can improve it if you want me to 