### PR TITLE
Handle single sample output from FeatureFunctionTransformer to support scikit-learn 1.7.2 and later

### DIFF
--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -62,7 +62,7 @@ class FeatureFunctionTransformer(FunctionTransformer):
 
         Returns
         -------
-        X_out : ndarray, shape (n_output_func,)
+        X_out : ndarray, shape (1, n_output_func)
             Usually, ``n_output_func`` will be equal to ``n_channels`` for most
             univariate feature functions and to
             ``(n_channels * (n_channels + 1)) // 2`` for most bivariate feature
@@ -71,6 +71,8 @@ class FeatureFunctionTransformer(FunctionTransformer):
         """
         X_out = super(FeatureFunctionTransformer, self).transform(X)
         self.output_shape_ = X_out.shape[0]
+        if X_out.ndim == 1:
+            X_out = X_out[np.newaxis, :]
         if not hasattr(self, 'feature_names_'):
             func_name = _get_func_name(self.func).replace('compute_', '')
             if (func_name in get_univariate_func_names() and


### PR DESCRIPTION
From scikit-learn 1.7.2, transformers used within FeatureUnion are required to return 2-dimensional outputs instead of 1-dimensional ones.
See the release notes:
https://scikit-learn.org/stable/whats_new/v1.7.html#sklearn-pipeline

Since all `compute_` functions return 1-D arrays, `extract_features` now raises an error such as:

```
ValueError: Transformer 'mean' returned an array or dataframe with 1 dimensions, but expected 2 dimensions (n_samples, n_features).
```

This PR fixes the output dimension of FeatureFunctionTransformer.transform to always be 2-D, rather than modifying each compute_ function.
This approach allows users to keep their custom feature-extraction functions unchanged.
