### PR TITLE
Update Python dependencies and fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Testing MNE-Features on Ubuntu 20.04
+name: Testing MNE-Features on the latest Ubuntu
 on:
   push:
     branches:
@@ -9,23 +9,35 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
-      PYTHON_VERSION: '3.8'
       CONDA_ENV: 'environment.yml'
     strategy:
       matrix:
-        python-version: [ "3.8" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         numba: [ "on", "off" ]
     continue-on-error: true
     name: python-${{ matrix.python-version }}-numba-${{ matrix.numba }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v5
+    # Sometimes setup-miniconda shows CondaHTTPError.
+    # To mitigate, following config is added.
+    # Jobs may still fail with CondaHTTPError. In than case, re-run the failed jobs.
+    # Ref: https://github.com/conda-incubator/setup-miniconda/issues/129
+    - name: Prepare conda config before installation
+      run: |
+        cat <<EOF > .condarc
+        remote_max_retries: 10
+        remote_backoff_factor: 5
+        remote_connect_timeout_secs: 60
+        remote_read_timeout_secs: 120
+        EOF
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: 'mne-features'
-        python-version: ${{ env.PYTHON_VERSION }}
+        python-version: ${{ matrix.python-version }}
         environment-file: ${{ env.CONDA_ENV }}
+        condarc-file: .condarc
       name: Install Miniconda and create environment
     - if: ${{ matrix.numba == 'off' }}
       shell: bash -el {0}
@@ -46,6 +58,6 @@ jobs:
       run: check-manifest --ignore doc,mne_features/*/tests
       name: Check manifest
     - name: Upload coverage stats
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mne-features
 channels:
 - conda-forge
 dependencies:
-- python>=3.8
+- python>=3.10,<3.14
 - mne
 - pip
 - numpy

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
                        'Programming Language :: Python :: 3',
                        ],
           platforms='any',
-          python_requires='>=3.6',
+          python_requires='>=3.10,<3.14',
           packages=package_tree('mne_features'),
           install_requires=['numpy', 'scipy', 'numba', 'scikit-learn', 'mne',
                             'PyWavelets', 'pandas'],


### PR DESCRIPTION
* ubuntu-20.04 is obsolete and no longer supported. Since this repository does not strongly depend on a specific OS version, it is better to use ubuntu-latest to simplify maintenance.
* Update outdated actions:
    * actions/checkout, conda-incubator/setup-miniconda, and codecov/codecov-action.
* Add Python 3.10 and 3.13 to the matrix strategy.
    * Python 3.8 has already reached end of life, and some libraries no longer support it with their latest versions.
    * The test suite should therefore include newer Python releases.
    * Python 3.9 will also reach end of life at the end of October.
    * Although Python 3.14 is the latest version, Numba does not yet support it ([numba/numba#9957](https://github.com/numba/numba/issues/9957)
).
    * Hence, Python 3.10 and 3.13 were added to the matrix.
* Remove `env.PYTHON_VERSION` and replace it with `matrix.python-version` for consistency with the workflow matrix configuration.

All tests will pass once #97 and #98 are merged.
Example test result is here: https://github.com/rcmdnk/mne-features/actions/runs/18524132632