### PR TITLE
Update for scikit-learn 1.8.0 and pandas 3.0.0 compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - matplotlib
 - numba
 - pandas
-- scikit-learn
+- scikit-learn>=1.6
 - PyWavelets
 - tqdm
 - download

--- a/mne_features/feature_extraction.py
+++ b/mne_features/feature_extraction.py
@@ -17,6 +17,7 @@ except (ImportError, ModuleNotFoundError):
     import joblib
 from sklearn.pipeline import FeatureUnion
 from sklearn.preprocessing import FunctionTransformer
+from sklearn.utils.validation import validate_data
 
 from .bivariate import get_bivariate_funcs, get_bivariate_func_names
 from .univariate import get_univariate_funcs, get_univariate_func_names
@@ -103,7 +104,13 @@ class FeatureFunctionTransformer(FunctionTransformer):
         -------
         self
         """
-        self._check_input(X, reset=True)
+        validate_data(
+            self,
+            X,
+            reset=True,
+            accept_sparse=self.accept_sparse,
+            skip_check_array=not self.validate,
+        )
         _feature_func = _get_python_func(self.func)
         if hasattr(_feature_func, 'get_feature_names'):
             _params = self.get_params()

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -306,7 +306,7 @@ def test_feature_names_quantile():
     df = extract_features(
         _data, sfreq, selected_funcs, funcs_params={'quantile__q': q},
         return_as_df=True)
-    assert_equal(df.columns.get_level_values(1).values, col_names)
+    assert_equal(df.columns.get_level_values(1).to_list(), col_names)
 
 
 def test_feature_names_spect_edge_freq():
@@ -325,7 +325,7 @@ def test_feature_names_spect_edge_freq():
             _data, sfreq, selected_funcs,
             funcs_params={'spect_edge_freq__edge': edge},
             return_as_df=True)
-        assert_equal(df.columns.get_level_values(1).values, col_names)
+        assert_equal(df.columns.get_level_values(1).to_list(), col_names)
 
 
 def test_feature_names_spect_slope():
@@ -338,7 +338,7 @@ def test_feature_names_spect_slope():
     col_names = ['ch%s_%s' % (ch, stat) for ch in range(n_chans) for
                  stat in stats]
     df = extract_features(_data, sfreq, selected_funcs, return_as_df=True)
-    assert_equal(df.columns.get_level_values(1).values, col_names)
+    assert_equal(df.columns.get_level_values(1).to_list(), col_names)
 
 
 def test_feature_names_wavelet_coef_energy(wavelet_name='db4'):
@@ -357,7 +357,7 @@ def test_feature_names_wavelet_coef_energy(wavelet_name='db4'):
         _data, sfreq, selected_funcs,
         funcs_params={'wavelet_coef_energy__wavelet_name': wavelet_name},
         return_as_df=True)
-    assert_equal(df.columns.get_level_values(1).values, col_names)
+    assert_equal(df.columns.get_level_values(1).to_list(), col_names)
 
 
 def test_feature_names_teager_kaiser_energy(wavelet_name='db4'):
@@ -376,7 +376,7 @@ def test_feature_names_teager_kaiser_energy(wavelet_name='db4'):
         _data, sfreq, selected_funcs,
         funcs_params={'teager_kaiser_energy__wavelet_name': wavelet_name},
         return_as_df=True)
-    assert_equal(df.columns.get_level_values(1).values, col_names)
+    assert_equal(df.columns.get_level_values(1).to_list(), col_names)
 
 
 def test_feature_names_pow_freq_bands():
@@ -402,7 +402,7 @@ def test_feature_names_pow_freq_bands():
             funcs_params={'pow_freq_bands__ratios': 'only',
                           'pow_freq_bands__freq_bands': fb},
             return_as_df=True)
-        assert_equal(df_only.columns.get_level_values(1).values, ratios_names)
+        assert_equal(df_only.columns.get_level_values(1).to_list(), ratios_names)
 
         # With `ratios = 'all'`:
         df_all = extract_features(
@@ -410,7 +410,7 @@ def test_feature_names_pow_freq_bands():
             funcs_params={'pow_freq_bands__ratios': 'all',
                           'pow_freq_bands__freq_bands': fb},
             return_as_df=True)
-        assert_equal(df_all.columns.get_level_values(1).values,
+        assert_equal(df_all.columns.get_level_values(1).to_list(),
                      pow_names + ratios_names)
 
         # With `ratios = None`:
@@ -419,7 +419,7 @@ def test_feature_names_pow_freq_bands():
             funcs_params={'pow_freq_bands__ratios': None,
                           'pow_freq_bands__freq_bands': fb},
             return_as_df=True)
-        assert_equal(df.columns.get_level_values(1).values, pow_names)
+        assert_equal(df.columns.get_level_values(1).to_list(), pow_names)
 
         # With `ratios = 'only'` and `ratios_triu = True`:
         df_only = extract_features(
@@ -428,7 +428,7 @@ def test_feature_names_pow_freq_bands():
                           'pow_freq_bands__ratios_triu': True,
                           'pow_freq_bands__freq_bands': fb},
             return_as_df=True)
-        assert_equal(df_only.columns.get_level_values(1).values,
+        assert_equal(df_only.columns.get_level_values(1).to_list(),
                      ratios_names[::2])
 
 
@@ -531,7 +531,7 @@ def test_feature_names_energy_freq_bands():
             _data, sfreq, selected_funcs,
             funcs_params={'energy_freq_bands__freq_bands': fb},
             return_as_df=True)
-        assert_equal(df.columns.get_level_values(1).values, feat_names)
+        assert_equal(df.columns.get_level_values(1).to_list(), feat_names)
 
 
 def test_spect_slope():

--- a/mne_features/tests/test_univariate.py
+++ b/mne_features/tests/test_univariate.py
@@ -402,7 +402,9 @@ def test_feature_names_pow_freq_bands():
             funcs_params={'pow_freq_bands__ratios': 'only',
                           'pow_freq_bands__freq_bands': fb},
             return_as_df=True)
-        assert_equal(df_only.columns.get_level_values(1).to_list(), ratios_names)
+        assert_equal(
+            df_only.columns.get_level_values(1).to_list(), ratios_names
+        )
 
         # With `ratios = 'all'`:
         df_all = extract_features(

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
           platforms='any',
           python_requires='>=3.10',
           packages=package_tree('mne_features'),
-          install_requires=['numpy', 'scipy', 'numba', 'scikit-learn', 'mne',
+          install_requires=['numpy', 'scipy', 'numba', 'scikit-learn>=1.6', 'mne',
                             'PyWavelets', 'pandas'],
           project_urls={
               'Documentation': 'https://mne-tools.github.io/mne-features/',


### PR DESCRIPTION
## scikit-learn 1.8.0

- Reference:  
  https://scikit-learn.org/stable/whats_new/v1.8.html  
  https://github.com/scikit-learn/scikit-learn/pull/31585

In scikit-learn 1.8.0, the private `_check_input` method was removed from
`FunctionTransformer`. Instead, `validate_data` is now called directly inside
`FunctionTransformer.fit`.

To align with this change, this PR updates:

- `mne_features/feature_extraction.py`
  - `FeatureFunctionTransformer.fit`

so that it calls `validate_data` directly, mirroring the behavior of
`FunctionTransformer.fit` in scikit-learn 1.8.0.

This avoids reliance on removed private APIs and ensures forward compatibility.

Note: scikit-learn 1.8.0 was released for Python >= 3.11.

---

## pandas 3.0.0

- Reference:  
  https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html

In pandas 3.0.0, calling `X.values` on a string-typed column now returns a
`pandas.arrays.StringArray` instead of a NumPy `ndarray`.

As a result, `numpy.testing.assert_equal` no longer works as expected and raises:

```
ValueError: The truth value of an array with more than one element is ambiguous.
Use a.any() or a.all().
```

To ensure correct and stable comparisons across pandas versions, this PR updates
the relevant tests in:

- `mne_features/tests/test_univariate.py`

Specifically, occurrences of `X.values` are replaced with `X.to_list()`, which
provides a plain Python list and avoids ambiguity when comparing string data.